### PR TITLE
Only enable niffler default features conditionally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crossbeam-channel = "0.5.14"
 either = "1.15.0"
 itertools = "0.14.0"
 memchr = "2.7.4"
-niffler = { version = "3.0.0", optional = true }
+niffler = { version = "3.0.0", optional = true, default-features = false }
 parking_lot = "0.12.3"
 reqwest = { version = "0.12.22", optional = true, features = ["blocking"] }
 rust-htslib = { version = "0.49.0", default-features = false, optional = true }
@@ -25,7 +25,7 @@ thiserror = "2.0.11"
 which = { version = "8.0.0", optional = true }
 
 [features]
-default = ["anyhow", "niffler"]
+default = ["anyhow", "niffler", "niffler/default"]
 anyhow = ["dep:anyhow"]
 niffler = ["dep:niffler"]
 htslib = ["dep:rust-htslib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paraseq"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Noam Teyssier"]
 keywords = ["fasta", "fastq", "parser", "parallel", "paired"]


### PR DESCRIPTION
This way they can be individually enabled/disabled by dependencies if needed (eg to speed up build times during development)


(A more refined approach based on this is also fine ofcourse.)