### PR TITLE
Add Reader::update_batch_size_in_bp(&mut self)

### DIFF
--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -162,6 +162,26 @@ impl<R: io::Read> Reader<R> {
         reader.batch_size = Some(batch_size);
         Ok(reader)
     }
+
+    /// Use the first record in the input to set the number of records per batch
+    /// so that the expected length per batch is approximately `batch_size_in_bp`.
+    pub fn update_batch_size_in_bp(&mut self, batch_size_in_bp: usize) -> Result<(), Error> {
+        let mut rset = self.new_record_set_with_size(1);
+        rset.fill(self)?;
+        let mut batch_size = 1;
+        if let Some(record) = rset.iter().next() {
+            let len = record?.seq_raw().len();
+            if len > 0 {
+                batch_size = batch_size_in_bp.div_ceil(len);
+            }
+        }
+        // Push the record back at the front of the reader.
+        self.reload(&mut rset);
+        // Update the batch size.
+        self.batch_size = Some(batch_size);
+        Ok(())
+    }
+
     /// Initialize a new record set with a configured or default batch size
     pub fn new_record_set(&self) -> RecordSet {
         if let Some(batch_size) = self.batch_size {

--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -177,6 +177,15 @@ impl<R: io::Read> Reader<R> {
         }
     }
 
+    /// Use the first record in the input to set the number of records per batch
+    /// so that the expected length per batch is approximately `batch_size_in_bp`.
+    pub fn update_batch_size_in_bp(&mut self, batch_size_in_bp: usize) -> Result<(), Error> {
+        match self {
+            Self::Fasta(inner) => inner.update_batch_size_in_bp(batch_size_in_bp),
+            Self::Fastq(inner) => inner.update_batch_size_in_bp(batch_size_in_bp),
+        }
+    }
+
     pub fn format(&self) -> Format {
         match self {
             Self::Fasta(_) => Format::Fasta,


### PR DESCRIPTION
Adds a utility function to update the record-set size in a reader based on a target size in bp and the length of the first record.
