### PR TITLE
Implementing a configurable read validation system that defaults to skipping validation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, str::Utf8Error};
 
 use thiserror::Error;
 
@@ -12,6 +12,13 @@ pub enum Error {
 
     #[error("Error reading from buffer: {0}")]
     Io(#[from] io::Error),
+
+    #[error("Error encountered while validating input data:\n\n{0}")]
+    ValidationError(#[from] crate::validation::error::ValidationError),
+
+    /// Error parsing valid UTF-8, indicating invalid characters in the input data.
+    #[error("Invalid UTF-8 error: {0}")]
+    Utf8Error(#[from] Utf8Error),
 
     #[cfg(feature = "url")]
     #[error("Networking error: {0}")]
@@ -43,6 +50,9 @@ pub enum Error {
 
     #[error("FASTQ Sequence length ({0}) and quality length ({1}) do not match")]
     UnequalLengths(usize, usize),
+
+    #[error("Paired records with different identifiers encountered when expected: {0} != {1}")]
+    PairedRecordsWithDifferentIds(String, String),
 
     #[error("Unexpected format request. Found fastx: {0}, requested: {1}")]
     UnexpectedFormatRequest(String, String),

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -4,7 +4,7 @@ use std::io;
 #[cfg(feature = "niffler")]
 use std::path::Path;
 
-use crate::{fastx::GenericReader, Error, Record, DEFAULT_MAX_RECORDS};
+use crate::{fastx::GenericReader, validation::ValidationMode, Error, Record, DEFAULT_MAX_RECORDS};
 
 pub struct Reader<R: io::Read> {
     /// Handle to the underlying reader (byte stream)
@@ -546,6 +546,16 @@ where
             .positions
             .iter()
             .map(move |&pos| Self::RefRecord::new(&record_set.buffer, pos))
+    }
+
+    fn check_read_pair(
+        rec1: &Self::RefRecord<'_>,
+        rec2: &Self::RefRecord<'_>,
+        mode: ValidationMode,
+    ) -> std::result::Result<(), Self::Error> {
+        mode.check_read_ids(rec1, rec2)?;
+
+        Ok(())
     }
 }
 

--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::io;
 
-use crate::{fasta, fastq, Error, Record};
+use crate::{fasta, fastq, validation::ValidationMode, Error, Record};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Format {
@@ -322,6 +322,7 @@ pub trait GenericReader: Send {
     fn check_read_pair(
         _rec1: &Self::RefRecord<'_>,
         _rec2: &Self::RefRecord<'_>,
+        _mode: ValidationMode,
     ) -> std::result::Result<(), Self::Error> {
         Ok(())
     }

--- a/src/htslib.rs
+++ b/src/htslib.rs
@@ -6,6 +6,7 @@ use rust_htslib::bam::{self, Read as BamRead};
 use thiserror::Error;
 
 use crate::fastx::GenericReader;
+use crate::validation::ValidationMode;
 use crate::DEFAULT_MAX_RECORDS;
 use crate::{
     parallel::{IntoProcessError, Result},
@@ -175,7 +176,15 @@ impl GenericReader for Reader {
         record_set.iter()
     }
 
-    fn check_read_pair(rec1: &Self::RefRecord<'_>, rec2: &Self::RefRecord<'_>) -> Result<()> {
+    fn check_read_pair(
+        rec1: &Self::RefRecord<'_>,
+        rec2: &Self::RefRecord<'_>,
+        mode: ValidationMode,
+    ) -> Result<()> {
+        if matches!(mode, ValidationMode::Skip) {
+            return Ok(());
+        }
+
         let rec1 = rec1.inner;
         let rec2 = rec2.inner;
         if !rec1.is_paired() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod fastx;
 pub mod parallel;
 pub mod prelude;
 mod record;
+pub mod validation;
 
 #[cfg(feature = "htslib")]
 pub mod htslib;

--- a/src/parallel/paired.rs
+++ b/src/parallel/paired.rs
@@ -3,6 +3,7 @@ use parking_lot::Mutex;
 
 use crate::fastx::GenericReader;
 use crate::parallel::error::ProcessError;
+use crate::validation::ValidationMode;
 
 use super::single::MTGenericReader;
 
@@ -63,7 +64,9 @@ where
         let record_iter = std::iter::zip(it1, it2).map(|(r1, r2)| {
             let r1 = r1?;
             let r2 = r2?;
-            R::check_read_pair(&r1, &r2)?;
+
+            let mode = ValidationMode::default();
+            R::check_read_pair(&r1, &r2, mode)?;
             std::result::Result::Ok((r1, r2))
         });
         either::Either::Right(record_iter)
@@ -110,9 +113,14 @@ where
             return either::Either::Left(error_iter);
         }
 
-        let tuple_iter = it
-            .tuples()
-            .map(|(r1, r2)| std::result::Result::Ok((r1?, r2?)));
+        let tuple_iter = it.tuples().map(|(r1, r2)| {
+            let r1 = r1?;
+            let r2 = r2?;
+
+            let mode = ValidationMode::default();
+            R::check_read_pair(&r1, &r2, mode)?;
+            std::result::Result::Ok((r1, r2))
+        });
         either::Either::Right(tuple_iter)
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,383 @@
+use std::str::FromStr;
+
+use crate::{validation::error::ValidationError, Record};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub enum ValidationMode {
+    #[default]
+    Skip,
+    Normal,
+    Strict,
+}
+
+impl FromStr for ValidationMode {
+    type Err = ValidationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s_lower = s.to_lowercase();
+        match s_lower.as_str() {
+            "skip" => Ok(Self::Skip),
+            "normal" => Ok(Self::Normal),
+            "strict" => Ok(Self::Strict),
+            val => Err(ValidationError::InvalidMode(val.to_string())),
+        }
+    }
+}
+
+impl From<bool> for ValidationMode {
+    fn from(value: bool) -> Self {
+        match value {
+            true => ValidationMode::Normal,
+            false => ValidationMode::Skip,
+        }
+    }
+}
+
+impl ValidationMode {
+    pub fn check_pair_id_suffixes<R: Record>(
+        self,
+        rec1: &R,
+        rec2: &R,
+    ) -> Result<(), ValidationError> {
+        if !matches!(self, ValidationMode::Strict) {
+            return Ok(());
+        };
+
+        let id1 = rec1.id();
+        let id2 = rec2.id();
+
+        if !id1.ends_with("/1".as_bytes()) {
+            let debug_str = str::from_utf8(id1)?.to_owned();
+            return Err(ValidationError::MissingForwardMateSuffix(debug_str));
+        }
+
+        if !id2.ends_with("/2".as_bytes()) {
+            let debug_str = str::from_utf8(id2)?.to_owned();
+            return Err(ValidationError::MissingReverseMateSuffix(debug_str));
+        }
+
+        Ok(())
+    }
+
+    pub fn check_read_ids<R: Record>(self, rec1: &R, rec2: &R) -> Result<(), ValidationError> {
+        if matches!(self, ValidationMode::Skip) {
+            return Ok(());
+        }
+
+        let id1 = rec1.id();
+        let id2 = rec2.id();
+
+        let ids_match = match (id1, id2) {
+            // Case 1: both have the /1 and /2 suffixes
+            (a @ [.., b'/', b'1'], b @ [.., b'/', b'2'])
+                if a[..a.len() - 2] == b[..b.len() - 2] =>
+            {
+                true
+            }
+
+            // Case 2: neither has the suffix — just compare the entire slices
+            (a, b) if a == b => true,
+
+            // Case 3: any other combination (mismatched suffixes, differing bases, etc.)
+            _ => false,
+        };
+
+        let id1_debug_str = str::from_utf8(id1)?.to_owned();
+        let id2_debug_str = str::from_utf8(id2)?.to_owned();
+        if !ids_match {
+            return Err(ValidationError::PairedRecordsWithDifferentIds(
+                id1_debug_str,
+                id2_debug_str,
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub fn validate_with<F>(self, func: F) -> Result<(), ValidationError>
+    where
+        F: FnOnce(ValidationMode) -> Result<(), ValidationError>,
+    {
+        func(self)
+    }
+
+    pub fn validate_record_with<R, F>(self, func: F, record: &R) -> Result<(), ValidationError>
+    where
+        R: Record,
+        F: FnOnce(ValidationMode, &R) -> Result<(), ValidationError>,
+    {
+        func(self, record)
+    }
+
+    pub fn validate_pair_with<R, F>(
+        self,
+        func: F,
+        rec1: &R,
+        rec2: &R,
+    ) -> Result<(), ValidationError>
+    where
+        R: Record,
+        F: FnOnce(ValidationMode, &R, &R) -> Result<(), ValidationError>,
+    {
+        func(self, rec1, rec2)
+    }
+
+    pub fn run_all_checks<R: Record>(self, rec1: &R, rec2: &R) -> Result<(), ValidationError> {
+        self.check_pair_id_suffixes(rec1, rec2)?;
+        self.check_read_ids(rec1, rec2)?;
+
+        Ok(())
+    }
+}
+
+pub mod error {
+
+    use std::str::Utf8Error;
+    use thiserror::Error;
+
+    pub type Result<T> = std::result::Result<T, ValidationError>;
+
+    #[derive(Debug, Error)]
+    pub enum ValidationError {
+        /// Invalid validation mode value provided
+        #[error("Invalid validation mode value provided: '{0}'. The mode must be 'strict', 'normal', or 'skip'.")]
+        InvalidMode(String),
+
+        /// Error parsing valid UTF-8, indicating invalid characters in the input data.
+        #[error("Invalid UTF-8 error: {0}")]
+        Utf8Error(#[from] Utf8Error),
+
+        #[error("FASTQ Sequence length ({0}) and quality length ({1}) do not match")]
+        UnequalLengths(usize, usize),
+
+        #[error("Paired records with different identifiers encountered when expected: {0} != {1}")]
+        PairedRecordsWithDifferentIds(String, String),
+
+        #[error("Validation in strict mode requires that forward read IDs come with a '/1' suffix, whereas the forward read id was '{0}'.")]
+        MissingForwardMateSuffix(String),
+
+        #[error("Validation in strict mode requires that reverse read IDs come with a '/2' suffix, whereas the reverse read id was '{0}'.")]
+        MissingReverseMateSuffix(String),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestRecord {
+        id: Vec<u8>,
+    }
+
+    impl Record for TestRecord {
+        fn id(&self) -> &[u8] {
+            &self.id
+        }
+
+        fn seq(&self) -> std::borrow::Cow<'_, [u8]> {
+            std::borrow::Cow::Borrowed(b"ACTG")
+        }
+
+        fn seq_raw(&self) -> &[u8] {
+            b"ACTG"
+        }
+
+        fn qual(&self) -> Option<&[u8]> {
+            Some(b"IIII")
+        }
+    }
+
+    #[test]
+    fn test_skip_mode_accepts_everything() {
+        let rec1 = TestRecord {
+            id: b"read1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"completely_different".to_vec(),
+        };
+
+        assert!(ValidationMode::Skip.check_read_ids(&rec1, &rec2).is_ok());
+    }
+
+    #[test]
+    fn test_normal_mode_matching_ids_with_suffixes() {
+        let rec1 = TestRecord {
+            id: b"read_name/1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_name/2".to_vec(),
+        };
+
+        assert!(ValidationMode::Normal.check_read_ids(&rec1, &rec2).is_ok());
+    }
+
+    #[test]
+    fn test_normal_mode_identical_ids_no_suffixes() {
+        let rec1 = TestRecord {
+            id: b"read_name".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_name".to_vec(),
+        };
+
+        assert!(ValidationMode::Normal.check_read_ids(&rec1, &rec2).is_ok());
+    }
+
+    #[test]
+    fn test_normal_mode_different_base_ids_with_suffixes() {
+        let rec1 = TestRecord {
+            id: b"read_A/1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_B/2".to_vec(),
+        };
+
+        let result = ValidationMode::Normal.check_read_ids(&rec1, &rec2);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            error::ValidationError::PairedRecordsWithDifferentIds(_, _)
+        ));
+    }
+
+    #[test]
+    fn test_normal_mode_mismatched_suffixes() {
+        let rec1 = TestRecord {
+            id: b"read_name/2".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_name/1".to_vec(),
+        };
+
+        let result = ValidationMode::Normal.check_read_ids(&rec1, &rec2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_normal_mode_only_one_has_suffix() {
+        let rec1 = TestRecord {
+            id: b"read_name/1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_name".to_vec(),
+        };
+
+        let result = ValidationMode::Normal.check_read_ids(&rec1, &rec2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_strict_mode_valid_suffixes() {
+        let rec1 = TestRecord {
+            id: b"read_name/1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_name/2".to_vec(),
+        };
+
+        assert!(ValidationMode::Strict
+            .check_pair_id_suffixes(&rec1, &rec2)
+            .is_ok());
+        assert!(ValidationMode::Strict.check_read_ids(&rec1, &rec2).is_ok());
+    }
+
+    #[test]
+    fn test_strict_mode_missing_forward_suffix() {
+        let rec1 = TestRecord {
+            id: b"read_name".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_name/2".to_vec(),
+        };
+
+        let result = ValidationMode::Strict.check_pair_id_suffixes(&rec1, &rec2);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            error::ValidationError::MissingForwardMateSuffix(_)
+        ));
+    }
+
+    #[test]
+    fn test_strict_mode_missing_reverse_suffix() {
+        let rec1 = TestRecord {
+            id: b"read_name/1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read_name".to_vec(),
+        };
+
+        let result = ValidationMode::Strict.check_pair_id_suffixes(&rec1, &rec2);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            error::ValidationError::MissingReverseMateSuffix(_)
+        ));
+    }
+
+    #[test]
+    fn test_validation_mode_from_str() {
+        assert!(matches!(
+            "skip".parse::<ValidationMode>().unwrap(),
+            ValidationMode::Skip
+        ));
+        assert!(matches!(
+            "normal".parse::<ValidationMode>().unwrap(),
+            ValidationMode::Normal
+        ));
+        assert!(matches!(
+            "strict".parse::<ValidationMode>().unwrap(),
+            ValidationMode::Strict
+        ));
+
+        assert!("SKIP".parse::<ValidationMode>().is_ok());
+        assert!("Normal".parse::<ValidationMode>().is_ok());
+
+        let result = "invalid".parse::<ValidationMode>();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            error::ValidationError::InvalidMode(_)
+        ));
+    }
+
+    #[test]
+    fn test_validation_mode_from_bool() {
+        assert!(matches!(ValidationMode::from(true), ValidationMode::Normal));
+        assert!(matches!(ValidationMode::from(false), ValidationMode::Skip));
+    }
+
+    #[test]
+    fn test_complex_read_id_with_suffixes() {
+        let rec1 = TestRecord {
+            id: b"@HISEQ:123:ABC:1:1101:1234:5678/1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"@HISEQ:123:ABC:1:1101:1234:5678/2".to_vec(),
+        };
+
+        assert!(ValidationMode::Normal.check_read_ids(&rec1, &rec2).is_ok());
+    }
+
+    #[test]
+    fn test_empty_ids() {
+        let rec1 = TestRecord { id: b"".to_vec() };
+        let rec2 = TestRecord { id: b"".to_vec() };
+
+        assert!(ValidationMode::Normal.check_read_ids(&rec1, &rec2).is_ok());
+    }
+
+    #[test]
+    fn test_run_all_checks() {
+        let rec1 = TestRecord {
+            id: b"read/1".to_vec(),
+        };
+        let rec2 = TestRecord {
+            id: b"read/2".to_vec(),
+        };
+
+        assert!(ValidationMode::Strict.run_all_checks(&rec1, &rec2).is_ok());
+        assert!(ValidationMode::Normal.run_all_checks(&rec1, &rec2).is_ok());
+        assert!(ValidationMode::Skip.run_all_checks(&rec1, &rec2).is_ok());
+    }
+}


### PR DESCRIPTION
This commit represents an incomplete solution to [issue #47](https://github.com/noamteyssier/paraseq/issues/47), which flagged the fact that FASTQ-derived paired reads are as-yet unvalidated in paraseq. The solution centers around a `ValidationMode` enum in the new validation module, which contains `ValidationMode`, trait impls and some helpful inherent methods on `ValidationMode`, an error submodule containing a `ValidationError` enum, and tests.

`ValidationMode` has three unit variants representing three levels of validation, which should be self-explanatory:

```rust
#[derive(Debug, Default, Clone, Copy)]
pub enum ValidationMode {
    #[default]
    Skip,
    Normal,
    Strict,
}
```

To make it easier to generate the enum from command line args, I’ve implemented `FromStr` on it, and for kicks you can convert it from a bool as well. It also implements `Copy` so that its value semantics reflect that it’s less expensive to copy than it is to take a reference.

The enum currently carries a couple of pre-implemented validation methods: one for checking that putatively paired reads contain `/1` and `/2` suffixes, and one for checking that read identifiers are the same, irrespective of those suffixes. However, I also gave it methods that allow users to apply their own validation logic as a closure—“bring your own validation!”

The part that remains, should we wish to complete this PR, is how to pass the chosen mode anywhere in the callstack where it may be needed, and how to expose it to the user for configuration. Ideally, we could do so without virally spreading the necessity of a new function argument, and also without any breaking changes.

With the setup described above, I can foresee at least a couple paths for integration.

#### 1) Expose via `GenericReader` and any types that impl it

In this path, we modify the trait `GenericReader` to provider a getter and a setter for the validation mode:

```rust
pub trait GenericReader: Send {
    ...

    fn validation_mode(&self) -> ValidationMode {
        ValidationMode::default()
    }

    fn set_validation_mode(&mut self, _mode: ValidationMode) {
        // Default no-op for types that don't support it
        // Implementors override this
    }

    ...
}
```

And then, we implement a new private field to store the validation mode, e.g., for `fastq::Reader`:

```rust
pub struct Reader<R: io::Read> {
    reader: R,
    overflow: Vec<u8>,
    eof: bool,
    batch_size: Option<usize>,
    validation_mode: ValidationMode // <- NEW
}

impl<R: io::Read> Reader<R> {
    pub fn new(reader: R) -> Self {
        Self {
            overflow: Vec::with_capacity(1024),
            reader,
            eof: false,
            batch_size: None,
            validation_mode: ValidationMode::default() // <- NEW
        }
    }
}
```

I’d probably also want to bring it in with your builder-pattern-ish API and add `.with_validation_mode()` as an interent method for types that are `GenericReader`.

This pathway has a couple of downsides:
1. Giving `.validation_mode()` a default impl to avoid breaking changes comes with a footgun: it will always return `ValidationMode::Skip` unless the user remembers to override the default `.validation_mode()` impl, which isn’t great.
2. If there’s more than one instance of types that are `GenericReader`, each will have its own mode setting, which introduces the need some method for forming a consensus. I’d do strictest-wins here, but this still introduces more machinery.

That said, this may be the best way to expose the validation API for any and all collections of records as opposed to the following pathway. It also puts validation mode alongside other lower-level reader settings like batch size. Plus, maybe it would be interesting to allow different validation strictnesses for reads from different circumstances?

#### 2) Expose via `MTGenericReader` and any types that impl it

It may instead make more sense to put an equivalent to the above getter and setter onto the slightly higher-level `MTGenericReader`, with the same builder-ish inherent methods for any types that impl it. Also like with the `GenericReader` pathway, this would require a new private field in the concrete reader types, e.g.:

```rust
struct SingleReader<R: GenericReader> {
    reader: Mutex<R>,
    validation_mode: ValidationMode, // <- NEW
}

impl<R: GenericReader> SingleReader<R> {
    pub fn new(reader1: R) -> Self {
        SingleReader {
            reader: Mutex::new(reader1),
            validation_mode: ValidationMode, // <- NEW
        }
    }
}
```

This approach also means we don’t need to implement validation mode consensus machinery, and it matches the level of abstraction where `.check_read_pair()` is called to boot:

```rust
impl<R: GenericReader> MTGenericReader for InterleavedPairedReader<R>
where
    ProcessError: From<R::Error>,
{
    ...

    fn iter(
        record_set: &Self::RecordSet,
    ) -> impl ExactSizeIterator<Item = std::result::Result<Self::RefRecord<'_>, Self::Error>> {
        let it = R::iter(record_set);

        if it.len() % 2 != 0 {
            let error_iter = std::iter::once(Err(ProcessError::IncompatibleInterleavedSetSize(it.len())));
            return either::Either::Left(error_iter);
        }

        let tuple_iter = it.tuples().map(|(r1, r2)| {
            let r1 = r1?;
            let r2 = r2?;

            R::check_read_pair(&r1, &r2, mode)?; // <- INTERNALLY CALLS VALIDATION MODE GETTER
            std::result::Result::Ok((r1, r2))
        });
        either::Either::Right(tuple_iter)
    }
}

```

This is one of those weird cases where I recognize that this is the better option, but for reasons I can’t put my finger on, I find myself preferring the first option.

There is one more option I can think of, though!

#### 3) Leave it out of the traits and just reference validation mode with inherent methods on the reader types

I like this option least, so I won’t spend too much time on it. Basically, this would just mean we couldn’t make generic default impls for methods like `.iter()` on `MTGenericReader`, which you already don’t do. In that case, if we put a validation mode field onto the reader types and gave them inherent getter and setter methods, accessing  the validation mode would have to look like this:

```rust
impl<R: GenericReader> MTGenericReader for InterleavedPairedReader<R>
where
    ProcessError: From<R::Error>,
{
    ...

    fn iter(
        record_set: &Self::RecordSet,
    ) -> impl ExactSizeIterator<Item =
std::result::Result<Self::RefRecord<'_>, Self::Error>> {
        let it = R::iter(record_set);

        if it.len() % 2 != 0 {
            let error_iter = std::iter::once(Err(ProcessError::IncompatibleInterleavedSetSize(it.len())));
            return either::Either::Left(error_iter);
        }

        let tuple_iter = it.tuples().map(|(r1, r2)| {
            let r1 = r1?;
            let r2 = r2?;

            let mode = self.validation_mode; // <- NEW. Could also be `self.get_validation_mode()` if that's implemented as an inherent method on `InterleavedPairedReader`
            R::check_read_pair(&r1, &r2, mode)?; // <- check_read_pair would have to accept the validation mode as its third arg
            std::result::Result::Ok((r1, r2))
        });
        either::Either::Right(tuple_iter)
    }
}
```

But what do you think? Does the enum-based approach feel right alongside the rest of the crate? Do any of these pathways seem like the way to go?

Thanks for reviewing!