### PR TITLE
feat(parallel): resizable worker pool for in-flight thread counts

### DIFF
--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -7,7 +7,9 @@ use log::warn;
 use crate::parallel::multi::{InterleavedMultiReader, MultiReader};
 use crate::parallel::paired::{InterleavedPairedReader, PairedReader};
 use crate::parallel::reader::{range_to_offset_limit, SingleReader};
-use crate::parallel::single::{process_parallel_generic, process_parallel_generic_range};
+use crate::parallel::single::{
+    process_parallel_generic, process_parallel_generic_range, process_parallel_pool_range,
+};
 use crate::ProcessError;
 use crate::{fasta, fastq, Error, Record};
 
@@ -197,6 +199,127 @@ impl<R: io::Read + Send> Collection<R> {
                 }
             }
 
+            Ok(())
+        })
+    }
+
+    /// As [`Self::handle_single_readers`], but every reader running at the same
+    /// time gets a share of one resizable pool.
+    ///
+    /// Readers within a batch run concurrently, so the pool is split
+    /// `batch_size` ways: the target the caller sets stays a *total* across the
+    /// run rather than a per-reader figure, matching what `total_threads` means
+    /// on the fixed path.
+    fn handle_single_readers_pool<T, F>(
+        mut self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+        scope_fn: F,
+    ) -> crate::Result<()>
+    where
+        T: Clone + Send,
+        F: Fn(Reader<R>, &mut T, &crate::parallel::ThreadPool) -> crate::Result<()> + Send + Sync,
+    {
+        let total_readers = self.inner.len().max(1);
+        let total_threads = num_cpus::get().min(pool.threads().max(1));
+        let threads_per_reader = match threads_per_reader {
+            Some(num) => num.min(total_threads).max(1),
+            None => (total_threads / total_readers).max(1),
+        };
+        let batch_size = (total_threads / threads_per_reader).max(1);
+        let num_batches = total_readers.div_ceil(batch_size);
+
+        thread::scope(|scope| -> crate::Result<()> {
+            let scope_fn = &scope_fn;
+
+            for _batch_idx in 0..num_batches {
+                let mut batch = Vec::new();
+                let rbound = batch_size.min(self.inner.len());
+                batch.extend(self.inner.drain(..rbound));
+                // Split across the readers actually in this batch, not the
+                // nominal batch size, or the last short batch would under-use
+                // the pool.
+                let ways = batch.len().max(1);
+
+                let mut subhandles = Vec::new();
+                for reader in batch {
+                    let mut thread_proc = processor.clone();
+                    let share = pool.share(ways);
+                    subhandles.push(scope.spawn(move || -> crate::Result<()> {
+                        scope_fn(reader, &mut thread_proc, &share)?;
+                        Ok(())
+                    }));
+                }
+                for handle in subhandles {
+                    handle
+                        .join()
+                        .map_err(|_| crate::ProcessError::JoinError)??;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    /// As [`Self::handle_grouped_readers`], but every group running at the same
+    /// time gets a share of one resizable pool.
+    fn handle_grouped_readers_pool<T, F>(
+        mut self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_group: Option<usize>,
+        arity: usize,
+        scope_fn: F,
+    ) -> crate::Result<()>
+    where
+        T: Clone + Send,
+        F: Fn(Vec<Reader<R>>, &mut T, &crate::parallel::ThreadPool) -> crate::Result<()>
+            + Send
+            + Sync,
+    {
+        let total_groups = (self.inner.len() / arity).max(1);
+        let total_threads = num_cpus::get().min(pool.threads().max(1));
+        let threads_per_group = match threads_per_group {
+            Some(num) => num.min(total_threads).max(1),
+            None => {
+                if total_threads >= arity {
+                    (total_threads / total_groups).max(arity)
+                } else {
+                    (total_threads / total_groups).max(1)
+                }
+            }
+        };
+        let batch_size = (total_threads / threads_per_group).max(1);
+        let num_batches = total_groups.div_ceil(batch_size);
+
+        thread::scope(|scope| -> crate::Result<()> {
+            let scope_fn = &scope_fn;
+
+            for _batch_idx in 0..num_batches {
+                let mut batch = Vec::new();
+                let groups_in_batch =
+                    batch_size.min(total_groups.saturating_sub(_batch_idx * batch_size));
+                for _ in 0..groups_in_batch {
+                    let group: Vec<_> = self.inner.drain(..arity).collect();
+                    batch.push(group);
+                }
+                let ways = batch.len().max(1);
+
+                let mut subhandles = Vec::new();
+                for group in batch {
+                    let mut thread_proc = processor.clone();
+                    let share = pool.share(ways);
+                    subhandles.push(scope.spawn(move || -> crate::Result<()> {
+                        scope_fn(group, &mut thread_proc, &share)?;
+                        Ok(())
+                    }));
+                }
+                for handle in subhandles {
+                    handle
+                        .join()
+                        .map_err(|_| crate::ProcessError::JoinError)??;
+                }
+            }
             Ok(())
         })
     }
@@ -623,6 +746,134 @@ impl<R: io::Read + Send> Collection<R> {
                     threads,
                     start,
                     limit,
+                )
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel`], but the worker count may change while the
+    /// run is in flight. See [`crate::parallel::ThreadPool`].
+    ///
+    /// The pool's target is a total across every reader running concurrently,
+    /// not a per-reader count.
+    pub fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::ParallelProcessor<RefRecord<'a>>,
+    {
+        self.warn_if_mismatch(CollectionType::Single);
+        self.handle_single_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            |reader, proc, share| {
+                process_parallel_pool_range(SingleReader::new(reader), proc, share, 0, None)
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_paired`], with a resizable worker count.
+    pub fn process_parallel_paired_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::PairedParallelProcessor<RefRecord<'a>>,
+    {
+        self.warn_if_mismatch(CollectionType::Paired);
+        self.handle_grouped_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            2,
+            |mut readers, proc, share| {
+                let r1 = readers.remove(0);
+                let r2 = readers.remove(0);
+                process_parallel_pool_range(PairedReader::new(r1, r2), proc, share, 0, None)
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_interleaved`], with a resizable worker count.
+    pub fn process_parallel_interleaved_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::PairedParallelProcessor<RefRecord<'a>>,
+    {
+        self.warn_if_mismatch(CollectionType::Interleaved);
+        self.handle_single_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            |reader, proc, share| {
+                process_parallel_pool_range(
+                    InterleavedPairedReader::new(reader),
+                    proc,
+                    share,
+                    0,
+                    None,
+                )
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_multi`], with a resizable worker count.
+    pub fn process_parallel_multi_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::MultiParallelProcessor<RefRecord<'a>>,
+        Self: Sized,
+    {
+        let arity = self.get_arity_for_multi();
+        self.handle_grouped_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            arity,
+            |readers, proc, share| {
+                process_parallel_pool_range(MultiReader::new(readers), proc, share, 0, None)
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_multi_interleaved`], with a resizable worker
+    /// count.
+    pub fn process_parallel_multi_interleaved_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::MultiParallelProcessor<RefRecord<'a>>,
+        Self: Sized,
+    {
+        let arity = self.get_arity_for_interleaved_multi();
+        self.handle_single_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            move |reader, proc, share| {
+                process_parallel_pool_range(
+                    InterleavedMultiReader::new(reader, arity),
+                    proc,
+                    share,
+                    0,
+                    None,
                 )
             },
         )

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -2,6 +2,7 @@ mod error;
 pub(crate) mod multi;
 mod ordered;
 pub(crate) mod paired;
+pub mod pool;
 mod processor;
 pub(crate) mod reader;
 pub(crate) mod single;
@@ -10,3 +11,5 @@ pub use error::{IntoProcessError, ProcessError, Result};
 pub use ordered::Ordered;
 pub use processor::{MultiParallelProcessor, PairedParallelProcessor, ParallelProcessor};
 pub use reader::ParallelReader;
+
+pub use pool::ThreadPool;

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -1,0 +1,145 @@
+//! A worker count that can change while a parallel run is in flight.
+//!
+//! # Why
+//!
+//! `process_parallel*` fixes its worker count when it is called. That is the
+//! right default, but it makes one class of decision unrecoverable: a caller
+//! that splits a fixed CPU budget between parsing/processing threads and some
+//! other consumer of the same budget — a parallel decompressor, say — has to
+//! choose the split before reading a byte, and cannot correct it afterwards.
+//!
+//! A [`ThreadPool`] lets that caller start somewhere reasonable and converge on
+//! evidence instead of committing up front.
+//!
+//! # Cost
+//!
+//! Workers are spawned on demand, not pre-spawned and parked. Pre-spawning is
+//! simpler but allocates a `RecordSet` per worker up front — at large batch
+//! sizes that is megabytes each, paid whether or not the worker ever runs.
+//!
+//! In exchange, a worker checks two relaxed atomics once per *batch* — not per
+//! record — and takes neither branch unless the target has actually moved.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct Inner {
+    /// Workers that should be running.
+    target: AtomicUsize,
+    /// Workers actually running. Only ever changed by a worker claiming or
+    /// releasing its own slot, so it cannot drift from reality.
+    live: AtomicUsize,
+    /// Hard ceiling. Bounds `target`, so a caller cannot ask for unbounded
+    /// threads by accident.
+    max: usize,
+}
+
+/// A shared, resizable worker count.
+///
+/// Cloning is cheap and every clone refers to the same pool.
+#[derive(Debug, Clone)]
+pub struct ThreadPool {
+    inner: Arc<Inner>,
+}
+
+impl ThreadPool {
+    /// A pool that never changes size — equivalent to passing `threads`
+    /// directly to `process_parallel*`.
+    pub fn new(threads: usize) -> Self {
+        Self::with_max(threads, threads)
+    }
+
+    /// A pool starting at `threads` that may later grow as far as `max`.
+    ///
+    /// `max` bounds growth only; it costs nothing until asked for, because
+    /// workers are spawned on demand.
+    pub fn with_max(threads: usize, max: usize) -> Self {
+        let max = max.max(1);
+        Self {
+            inner: Arc::new(Inner {
+                target: AtomicUsize::new(threads.clamp(1, max)),
+                live: AtomicUsize::new(0),
+                max,
+            }),
+        }
+    }
+
+    /// Change how many workers should be running.
+    ///
+    /// Takes effect within one batch per worker: growth spawns as running
+    /// workers notice the gap, and shrinking retires workers after they finish
+    /// the batch in hand. Never interrupts work in progress, so no record is
+    /// processed twice or dropped.
+    pub fn set_threads(&self, threads: usize) {
+        self.inner
+            .target
+            .store(threads.clamp(1, self.inner.max), Ordering::Relaxed);
+    }
+
+    /// The current target.
+    pub fn threads(&self) -> usize {
+        self.inner.target.load(Ordering::Relaxed)
+    }
+
+    /// Workers actually running now.
+    pub fn live(&self) -> usize {
+        self.inner.live.load(Ordering::Relaxed)
+    }
+
+    /// The ceiling set at construction.
+    pub fn max_threads(&self) -> usize {
+        self.inner.max
+    }
+
+    /// Claim a slot for a new worker, if the pool is short of its target.
+    ///
+    /// A CAS rather than a load-then-store because several workers may notice
+    /// the same shortfall at once, and two of them spawning for one slot would
+    /// overshoot the target.
+    pub(crate) fn try_claim_slot(&self) -> bool {
+        let mut live = self.inner.live.load(Ordering::Relaxed);
+        loop {
+            let target = self.inner.target.load(Ordering::Relaxed);
+            if live >= target || live >= self.inner.max {
+                return false;
+            }
+            match self.inner.live.compare_exchange_weak(
+                live,
+                live + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => live = actual,
+            }
+        }
+    }
+
+    /// Release this worker's slot if the pool is over its target.
+    ///
+    /// Symmetric to [`Self::try_claim_slot`]: the CAS is what stops every
+    /// surplus worker retiring at once when the target drops by one.
+    pub(crate) fn try_release_slot(&self) -> bool {
+        let mut live = self.inner.live.load(Ordering::Relaxed);
+        loop {
+            if live <= self.inner.target.load(Ordering::Relaxed) || live <= 1 {
+                return false;
+            }
+            match self.inner.live.compare_exchange_weak(
+                live,
+                live - 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => live = actual,
+            }
+        }
+    }
+
+    /// Release unconditionally, for a worker leaving because the input ended.
+    pub(crate) fn release_slot(&self) {
+        self.inner.live.fetch_sub(1, Ordering::AcqRel);
+    }
+}

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -32,6 +32,15 @@ struct Inner {
     target: AtomicUsize,
     /// Hard ceiling on `target`.
     max: usize,
+    /// Workers live across *every* share of this pool.
+    ///
+    /// Each share tracks its own count to enforce its own slice, but a caller
+    /// supervising the whole run needs the total — and summing shares is not
+    /// possible from outside, because a share is handed to a worker thread and
+    /// never surfaced. Without this, an external scheduler normalising work
+    /// against "threads running" divides by the parent's count, which stays at
+    /// zero for the entire run.
+    total_live: AtomicUsize,
 }
 
 /// A shared, resizable worker count.
@@ -67,6 +76,7 @@ impl ThreadPool {
             inner: Arc::new(Inner {
                 target: AtomicUsize::new(threads.clamp(1, max)),
                 max,
+                total_live: AtomicUsize::new(0),
             }),
             live: Arc::new(AtomicUsize::new(0)),
             divisor: 1,
@@ -114,6 +124,15 @@ impl ThreadPool {
         self.live.load(Ordering::Relaxed)
     }
 
+    /// Workers running across every share of this pool.
+    ///
+    /// This is the figure a supervisor wants. [`Self::live`] reports only the
+    /// share it is called on, and the pool a caller holds is the *parent*, whose
+    /// own share never runs anything when a `Collection` splits it.
+    pub fn total_live(&self) -> usize {
+        self.inner.total_live.load(Ordering::Relaxed)
+    }
+
     /// The ceiling set at construction, across every share.
     pub fn max_threads(&self) -> usize {
         self.inner.max
@@ -146,7 +165,10 @@ impl ThreadPool {
                 Ordering::AcqRel,
                 Ordering::Relaxed,
             ) {
-                Ok(_) => return true,
+                Ok(_) => {
+                    self.inner.total_live.fetch_add(1, Ordering::AcqRel);
+                    return true;
+                }
                 Err(actual) => live = actual,
             }
         }
@@ -168,7 +190,10 @@ impl ThreadPool {
                 Ordering::AcqRel,
                 Ordering::Relaxed,
             ) {
-                Ok(_) => return true,
+                Ok(_) => {
+                    self.inner.total_live.fetch_sub(1, Ordering::AcqRel);
+                    return true;
+                }
                 Err(actual) => live = actual,
             }
         }
@@ -177,5 +202,6 @@ impl ThreadPool {
     /// Release unconditionally, for a worker leaving because the input ended.
     pub(crate) fn release_slot(&self) {
         self.live.fetch_sub(1, Ordering::AcqRel);
+        self.inner.total_live.fetch_sub(1, Ordering::AcqRel);
     }
 }

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -25,22 +25,29 @@ use std::sync::Arc;
 
 #[derive(Debug)]
 struct Inner {
-    /// Workers that should be running.
+    /// Workers that should be running, across every share of this pool.
+    ///
+    /// Shared by all shares so that one `set_threads` reaches every reader a
+    /// `Collection` is driving, without anything having to fan the change out.
     target: AtomicUsize,
-    /// Workers actually running. Only ever changed by a worker claiming or
-    /// releasing its own slot, so it cannot drift from reality.
-    live: AtomicUsize,
-    /// Hard ceiling. Bounds `target`, so a caller cannot ask for unbounded
-    /// threads by accident.
+    /// Hard ceiling on `target`.
     max: usize,
 }
 
 /// A shared, resizable worker count.
 ///
-/// Cloning is cheap and every clone refers to the same pool.
+/// Cloning is cheap and every clone refers to the same pool. A `Collection`
+/// driving several readers at once gives each one a [`share`](Self::share) of
+/// the same pool, so the target the caller sets is a *total* rather than a
+/// per-reader figure.
 #[derive(Debug, Clone)]
 pub struct ThreadPool {
     inner: Arc<Inner>,
+    /// Workers running in *this* share. Only ever changed by a worker claiming
+    /// or releasing its own slot, so it cannot drift from reality.
+    live: Arc<AtomicUsize>,
+    /// How many shares divide `inner.target`. One for an unshared pool.
+    divisor: usize,
 }
 
 impl ThreadPool {
@@ -59,13 +66,33 @@ impl ThreadPool {
         Self {
             inner: Arc::new(Inner {
                 target: AtomicUsize::new(threads.clamp(1, max)),
-                live: AtomicUsize::new(0),
                 max,
             }),
+            live: Arc::new(AtomicUsize::new(0)),
+            divisor: 1,
         }
     }
 
-    /// Change how many workers should be running.
+    /// A view of this pool for one of `ways` concurrent consumers.
+    ///
+    /// Each share tracks its own live workers but reads the same target, so a
+    /// `set_threads` on any of them retargets all of them at once. The target
+    /// is a total: `ways` shares of a 32-thread pool run 8 workers each.
+    ///
+    /// Sharing rather than handing the same pool to every reader is deliberate.
+    /// A single pool would let the first reader claim every slot, leaving the
+    /// rest to spawn nothing — and since workers are only spawned *by* running
+    /// workers, those readers would never start and their input would be
+    /// silently skipped.
+    pub fn share(&self, ways: usize) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            live: Arc::new(AtomicUsize::new(0)),
+            divisor: self.divisor.saturating_mul(ways.max(1)).max(1),
+        }
+    }
+
+    /// Change how many workers should be running, across every share.
     ///
     /// Takes effect within one batch per worker: growth spawns as running
     /// workers notice the gap, and shrinking retires workers after they finish
@@ -77,19 +104,29 @@ impl ThreadPool {
             .store(threads.clamp(1, self.inner.max), Ordering::Relaxed);
     }
 
-    /// The current target.
+    /// The current target, across every share.
     pub fn threads(&self) -> usize {
         self.inner.target.load(Ordering::Relaxed)
     }
 
-    /// Workers actually running now.
+    /// Workers running in this share.
     pub fn live(&self) -> usize {
-        self.inner.live.load(Ordering::Relaxed)
+        self.live.load(Ordering::Relaxed)
     }
 
-    /// The ceiling set at construction.
+    /// The ceiling set at construction, across every share.
     pub fn max_threads(&self) -> usize {
         self.inner.max
+    }
+
+    /// This share's slice of the target, never below one.
+    pub(crate) fn share_target(&self) -> usize {
+        (self.threads() / self.divisor).max(1)
+    }
+
+    /// This share's slice of the ceiling, never below one.
+    pub(crate) fn share_max(&self) -> usize {
+        (self.inner.max / self.divisor).max(1)
     }
 
     /// Claim a slot for a new worker, if the pool is short of its target.
@@ -98,13 +135,12 @@ impl ThreadPool {
     /// the same shortfall at once, and two of them spawning for one slot would
     /// overshoot the target.
     pub(crate) fn try_claim_slot(&self) -> bool {
-        let mut live = self.inner.live.load(Ordering::Relaxed);
+        let mut live = self.live.load(Ordering::Relaxed);
         loop {
-            let target = self.inner.target.load(Ordering::Relaxed);
-            if live >= target || live >= self.inner.max {
+            if live >= self.share_target() || live >= self.share_max() {
                 return false;
             }
-            match self.inner.live.compare_exchange_weak(
+            match self.live.compare_exchange_weak(
                 live,
                 live + 1,
                 Ordering::AcqRel,
@@ -121,12 +157,12 @@ impl ThreadPool {
     /// Symmetric to [`Self::try_claim_slot`]: the CAS is what stops every
     /// surplus worker retiring at once when the target drops by one.
     pub(crate) fn try_release_slot(&self) -> bool {
-        let mut live = self.inner.live.load(Ordering::Relaxed);
+        let mut live = self.live.load(Ordering::Relaxed);
         loop {
-            if live <= self.inner.target.load(Ordering::Relaxed) || live <= 1 {
+            if live <= self.share_target() || live <= 1 {
                 return false;
             }
-            match self.inner.live.compare_exchange_weak(
+            match self.live.compare_exchange_weak(
                 live,
                 live - 1,
                 Ordering::AcqRel,
@@ -140,6 +176,6 @@ impl ThreadPool {
 
     /// Release unconditionally, for a worker leaving because the input ended.
     pub(crate) fn release_slot(&self) {
-        self.inner.live.fetch_sub(1, Ordering::AcqRel);
+        self.live.fetch_sub(1, Ordering::AcqRel);
     }
 }

--- a/src/parallel/reader.rs
+++ b/src/parallel/reader.rs
@@ -31,6 +31,16 @@ pub trait ParallelReader {
     where
         T: for<'a> ParallelProcessor<Self::Rf<'a>>;
 
+    /// As [`Self::process_parallel`], but the worker count may change while the
+    /// run is in flight. See [`crate::parallel::ThreadPool`].
+    fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+    ) -> Result<()>
+    where
+        T: for<'a> ParallelProcessor<Self::Rf<'a>>;
+
     fn process_parallel_paired<T>(
         self,
         r2: Self,
@@ -116,6 +126,23 @@ where
         T: for<'a> ParallelProcessor<S::RefRecord<'a>>,
     {
         process_parallel_generic(SingleReader::new(self), processor, num_threads)
+    }
+
+    fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+    ) -> Result<()>
+    where
+        T: for<'a> ParallelProcessor<S::RefRecord<'a>>,
+    {
+        crate::parallel::single::process_parallel_pool_range(
+            SingleReader::new(self),
+            processor,
+            pool,
+            0,
+            None,
+        )
     }
 
     fn process_parallel_range<T>(

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -1124,6 +1124,52 @@ mod pool_tests {
         assert_eq!(proc.total.load(Ordering::Relaxed), N);
     }
 
+    /// A supervisor outside the run needs the aggregate live count.
+    ///
+    /// `live()` reports one share, and the pool a caller holds is the *parent*,
+    /// whose own share never runs anything once a `Collection` splits it — so the
+    /// obvious reading is zero for the whole run. An external scheduler normalising
+    /// work against "threads running" then divides by nothing and concludes the
+    /// consumer is never busy.
+    #[test]
+    fn total_live_counts_workers_across_every_share() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(8, 8);
+        let observer = pool.clone();
+        let seen = Arc::new(AtomicUsize::new(0));
+        let s2 = Arc::clone(&seen);
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let st2 = Arc::clone(&stop);
+        let watcher = std::thread::spawn(move || {
+            while !st2.load(Ordering::Relaxed) {
+                s2.fetch_max(observer.total_live(), Ordering::Relaxed);
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+        });
+
+        let mut proc = TallyProcessor::default();
+        let inner: Vec<_> = (0..4)
+            .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+            .collect();
+        Collection::new(inner, CollectionType::Single)
+            .unwrap()
+            .process_parallel_pool(&mut proc, &pool, None)
+            .unwrap();
+        stop.store(true, Ordering::Relaxed);
+        watcher.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N * 4);
+        assert!(
+            seen.load(Ordering::Relaxed) > 1,
+            "peak total_live was {}, so shares are invisible to the parent",
+            seen.load(Ordering::Relaxed)
+        );
+        // And it unwinds: nothing is left counted after the run.
+        assert_eq!(pool.total_live(), 0, "live count leaked after the run");
+    }
+
     /// A `Collection` splits its pool across the readers running at once.
     ///
     /// The regression this guards: handing every reader the *same* pool lets

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -141,14 +141,14 @@ pub(crate) fn process_parallel_pool_range<S: MTGenericReader, T>(
 where
     T: for<'a> GenericProcessor<S::RefRecord<'a>>,
 {
-    let mut num_threads = pool.threads();
+    let mut num_threads = pool.share_target();
     if num_threads == 0 {
         num_threads = num_cpus::get();
     }
     // Only when the pool can never grow. A pool that *starts* at one worker but
     // may be resized has to take the parallel path anyway, or it could never
     // honour a later `set_threads` -- there is no pool in the sequential path.
-    if num_threads == 1 && pool.max_threads() == 1 {
+    if num_threads == 1 && pool.share_max() == 1 {
         return process_sequential_generic_range(reader, processor, offset, limit);
     }
 
@@ -196,6 +196,12 @@ where
             limit,
         };
 
+        // At least one worker always starts: `share_target` floors at one and a
+        // share's live count starts at zero, so the first claim cannot fail.
+        // That matters more than it looks -- a share that spawned no workers
+        // would return immediately and silently skip its whole input, and no
+        // later growth could rescue it, because only a running worker spawns
+        // another.
         for _ in 0..num_threads {
             if !pool.try_claim_slot() {
                 break;
@@ -1116,6 +1122,102 @@ mod pool_tests {
         churner.join().unwrap();
 
         assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// A `Collection` splits its pool across the readers running at once.
+    ///
+    /// The regression this guards: handing every reader the *same* pool lets
+    /// the first claim every slot, so the rest spawn nothing. Since only a
+    /// running worker spawns another, those readers never start and their input
+    /// is silently skipped -- the counts come back short, with no error.
+    #[test]
+    fn a_collection_processes_every_reader_from_a_shared_pool() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 5_000;
+        for readers in [1usize, 2, 4, 8] {
+            let mut proc = TallyProcessor::default();
+            let inner: Vec<_> = (0..readers)
+                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+                .collect();
+            let collection = Collection::new(inner, CollectionType::Single).unwrap();
+            // Fewer threads than readers, so the split rounds down toward zero
+            // and every share has to be floored at one.
+            collection
+                .process_parallel_pool(&mut proc, &ThreadPool::new(2), None)
+                .unwrap();
+            assert_eq!(
+                proc.total.load(Ordering::Relaxed),
+                N * readers,
+                "{readers} readers: some reader was never started"
+            );
+        }
+    }
+
+    /// The same, for the grouped (paired) dispatch path.
+    #[test]
+    fn a_paired_collection_processes_every_group() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 4_000;
+        #[derive(Clone, Default)]
+        struct PairTally {
+            total: Arc<AtomicUsize>,
+            local: usize,
+        }
+        impl<Rf: Record> crate::parallel::PairedParallelProcessor<Rf> for PairTally {
+            fn process_record_pair(&mut self, _r1: Rf, _r2: Rf) -> Result<(), ProcessError> {
+                self.local += 1;
+                Ok(())
+            }
+            fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
+                self.total.fetch_add(self.local, Ordering::Relaxed);
+                self.local = 0;
+                Ok(())
+            }
+        }
+
+        for pairs in [1usize, 2, 4] {
+            let mut proc = PairTally::default();
+            let inner: Vec<_> = (0..pairs * 2)
+                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+                .collect();
+            let collection = Collection::new(inner, CollectionType::Paired).unwrap();
+            collection
+                .process_parallel_paired_pool(&mut proc, &ThreadPool::new(2), None)
+                .unwrap();
+            assert_eq!(
+                proc.total.load(Ordering::Relaxed),
+                N * pairs,
+                "{pairs} pairs: some group was never started"
+            );
+        }
+    }
+
+    /// A share reads the same target as its parent, so one `set_threads`
+    /// retargets every reader at once.
+    #[test]
+    fn shares_track_the_parent_target() {
+        let pool = ThreadPool::with_max(16, 32);
+        let a = pool.share(4);
+        let b = pool.share(4);
+        assert_eq!(a.share_target(), 4);
+        assert_eq!(b.share_target(), 4);
+
+        pool.set_threads(32);
+        assert_eq!(a.share_target(), 8, "a share must see the parent resize");
+        assert_eq!(b.share_target(), 8);
+
+        // A share never rounds down to zero workers.
+        let thin = pool.share(64);
+        assert_eq!(thin.share_target(), 1);
+        assert_eq!(thin.share_max(), 1);
+
+        // Live counts are per share, not shared: claiming in one leaves the
+        // other untouched.
+        assert!(a.try_claim_slot());
+        assert_eq!(a.live(), 1);
+        assert_eq!(b.live(), 0);
     }
 
     /// A pool never exceeds the ceiling it was built with.

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -3,8 +3,8 @@ use itertools::Itertools;
 use crate::parallel::ordered::OrderGate;
 use crate::parallel::processor::GenericProcessor;
 use crate::parallel::{error::Result, ProcessError};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 /// A Sync version of GenericReader, i.e. for types with internal mutexes that can be shared between threads.
@@ -108,19 +108,47 @@ where
 }
 
 pub(crate) fn process_parallel_generic_range<S: MTGenericReader, T>(
-    mut reader: S,
+    reader: S,
     processor: &mut T,
-    mut num_threads: usize,
+    num_threads: usize,
     offset: usize,
     limit: Option<usize>,
 ) -> Result<()>
 where
     T: for<'a> GenericProcessor<S::RefRecord<'a>>,
 {
+    // A pool whose target never moves is exactly a fixed worker count. There is
+    // one implementation rather than two, so the resizable path cannot drift
+    // from the fixed one.
+    process_parallel_pool_range(
+        reader,
+        processor,
+        &crate::parallel::ThreadPool::new(num_threads),
+        offset,
+        limit,
+    )
+}
+
+/// As [`process_parallel_generic_range`], but the worker count may change while
+/// the run is in flight. See [`crate::parallel::ThreadPool`].
+pub(crate) fn process_parallel_pool_range<S: MTGenericReader, T>(
+    mut reader: S,
+    processor: &mut T,
+    pool: &crate::parallel::ThreadPool,
+    offset: usize,
+    limit: Option<usize>,
+) -> Result<()>
+where
+    T: for<'a> GenericProcessor<S::RefRecord<'a>>,
+{
+    let mut num_threads = pool.threads();
     if num_threads == 0 {
         num_threads = num_cpus::get();
     }
-    if num_threads == 1 {
+    // Only when the pool can never grow. A pool that *starts* at one worker but
+    // may be resized has to take the parallel path anyway, or it could never
+    // honour a later `set_threads` -- there is no pool in the sequential path.
+    if num_threads == 1 && pool.max_threads() == 1 {
         return process_sequential_generic_range(reader, processor, offset, limit);
     }
 
@@ -130,113 +158,207 @@ where
     let order_gate = Arc::new(OrderGate::new());
     let ordered = processor.requires_ordering();
 
+    // Workers spawned after the initial wave are in no handle list, so their
+    // errors are collected here rather than by `join`. `thread::scope` still
+    // joins every worker before its closure returns, so reading this afterwards
+    // cannot race.
+    let first_error: Mutex<Option<ProcessError>> = Mutex::new(None);
+    let next_id = AtomicUsize::new(0);
+    // Set as soon as any worker sees the input end.
+    //
+    // Without it, a worker leaving at EOF drops `live` below `target`, every
+    // remaining worker reads that as "the pool is short", and each spawns a
+    // replacement that immediately hits EOF and does the same. Measured before
+    // this existed: 3.1 million workers spawned for a 32-thread run.
+    let finished = AtomicBool::new(false);
+    // New workers are cloned from this, never from a running worker.
+    //
+    // `Clone` on a processor means "give me a fresh worker" -- the fixed path
+    // only ever clones the caller's untouched instance. Cloning a worker
+    // mid-flight instead copies whatever it has accumulated, and any processor
+    // keeping per-thread tallies then double-counts them when both flush in
+    // `on_thread_complete`. That turned an 8 million record file into 791
+    // billion records.
+    let template: Mutex<T> = Mutex::new(processor.clone());
+
     thread::scope(|scope| -> Result<()> {
         let reader = &reader;
+        let ctx = WorkerCtx {
+            reader,
+            pool,
+            next_id: &next_id,
+            first_error: &first_error,
+            finished: &finished,
+            template: &template,
+            order_gate: &order_gate,
+            ordered,
+            offset,
+            limit,
+        };
 
-        let mut handles = Vec::new();
-        for thread_id in 0..num_threads {
-            let mut worker_processor = processor.clone();
-            let mut record_set = reader.new_record_set();
-            let records_processed = records_processed.clone();
-            let order_gate = order_gate.clone();
-
-            let handle = scope.spawn(move || {
-                // Run the worker body in a closure so any error path below can
-                // poison the order gate before propagating - otherwise other
-                // threads waiting on a batch that will never complete would
-                // deadlock instead of unwinding.
-                let result: Result<()> = (|| {
-                    worker_processor.set_thread_id(thread_id);
-
-                    loop {
-                        // Check limit before grabbing batch
-                        if let Some(lim) = limit {
-                            if records_processed.load(Ordering::Relaxed) >= lim {
-                                break;
-                            }
-                        }
-
-                        // Fill the batch; `fill` itself claims this batch's
-                        // stream position atomically (see the trait docs).
-                        let Some((batch_start, batch_end)) =
-                            reader.fill(&mut record_set).map_err(Into::into)?
-                        else {
-                            break; // EOF
-                        };
-                        let batch_size = batch_end - batch_start;
-
-                        // Determine overlap with target range [offset, offset+limit)
-                        let range_end = limit.map(|lim| offset + lim).unwrap_or(usize::MAX);
-
-                        if batch_end <= offset {
-                            // Entire batch before offset - skip it. Still catch
-                            // the order gate up to this point so the first
-                            // processed batch's wait_turn isn't stuck waiting
-                            // for skipped ground it will never claim.
-                            if ordered {
-                                order_gate.advance(batch_end);
-                            }
-                            continue;
-                        }
-
-                        if batch_start >= range_end {
-                            // Entire batch after limit - done
-                            break;
-                        }
-
-                        // Calculate slice of this batch within range
-                        let skip_in_batch = offset.saturating_sub(batch_start);
-                        let take_count = (batch_size - skip_in_batch)
-                            .min(range_end - batch_start - skip_in_batch);
-
-                        // Process the slice
-                        let records = S::iter(&record_set)
-                            .skip(skip_in_batch)
-                            .take(take_count)
-                            .map(|r| r.map_err(Into::into));
-
-                        records.process_results(|records| {
-                            worker_processor.process_record_batch(records)
-                        })??;
-
-                        records_processed.fetch_add(take_count, Ordering::Relaxed);
-
-                        // Only the commit step is serialized to stream order;
-                        // process_record_batch above already ran unordered.
-                        if ordered {
-                            order_gate.wait_turn(batch_start);
-                        }
-                        worker_processor.on_batch_complete()?;
-                        if ordered {
-                            order_gate.advance(batch_end);
-                        }
-                    }
-                    worker_processor.on_thread_complete()?;
-                    Ok(())
-                })();
-
-                if result.is_err() && ordered {
-                    order_gate.poison();
-                }
-                result
-            });
-
-            handles.push(handle);
-        }
-
-        // Wait for workers
-        for handle in handles {
-            match handle.join() {
-                Ok(Ok(())) => (),
-                Ok(Err(e)) => return Err(e),
-                Err(_) => return Err(ProcessError::JoinError),
+        for _ in 0..num_threads {
+            if !pool.try_claim_slot() {
+                break;
             }
+            spawn_worker(
+                scope,
+                &ctx,
+                processor.clone(),
+                reader.new_record_set(),
+                records_processed.clone(),
+            );
         }
-
         Ok(())
     })?;
 
-    Ok(())
+    match first_error.into_inner().unwrap_or(None) {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Everything a worker needs that is identical for every worker.
+///
+/// Grouped so that spawning one takes three arguments rather than a dozen, and
+/// so a worker can hand the same context to a successor.
+struct WorkerCtx<'env, S, T> {
+    reader: &'env S,
+    pool: &'env crate::parallel::ThreadPool,
+    next_id: &'env AtomicUsize,
+    first_error: &'env Mutex<Option<ProcessError>>,
+    finished: &'env AtomicBool,
+    template: &'env Mutex<T>,
+    order_gate: &'env Arc<OrderGate>,
+    ordered: bool,
+    offset: usize,
+    limit: Option<usize>,
+}
+
+impl<S, T> Clone for WorkerCtx<'_, S, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<S, T> Copy for WorkerCtx<'_, S, T> {}
+
+/// Run one worker, and let it spawn successors when the pool grows.
+///
+/// Spawning from inside a worker rather than from a dedicated coordinator puts
+/// the cost where it is already amortised: a worker checks the pool once per
+/// *batch*, between finishing one and asking for the next. No coordinator
+/// thread, and no polling interval to tune.
+fn spawn_worker<'scope, 'env, S, T>(
+    scope: &'scope thread::Scope<'scope, 'env>,
+    ctx: &WorkerCtx<'env, S, T>,
+    mut worker_processor: T,
+    mut record_set: S::RecordSet,
+    records_processed: Arc<AtomicUsize>,
+) where
+    S: MTGenericReader + Sync + 'env,
+    T: for<'a> GenericProcessor<S::RefRecord<'a>> + Send + 'env,
+{
+    let ctx = *ctx;
+    let thread_id = ctx.next_id.fetch_add(1, Ordering::Relaxed);
+    scope.spawn(move || {
+        let mut retired = false;
+
+        // As in the fixed path: run the body in a closure so any error can
+        // poison the order gate before propagating, rather than deadlocking
+        // workers waiting on a batch that will never complete.
+        let result: Result<()> = (|| {
+            worker_processor.set_thread_id(thread_id);
+
+            loop {
+                if let Some(lim) = ctx.limit {
+                    if records_processed.load(Ordering::Relaxed) >= lim {
+                        ctx.finished.store(true, Ordering::Relaxed);
+                        break;
+                    }
+                }
+
+                let Some((batch_start, batch_end)) =
+                    ctx.reader.fill(&mut record_set).map_err(Into::into)?
+                else {
+                    ctx.finished.store(true, Ordering::Relaxed);
+                    break; // EOF
+                };
+                let batch_size = batch_end - batch_start;
+                let range_end = ctx.limit.map(|lim| ctx.offset + lim).unwrap_or(usize::MAX);
+
+                if batch_end <= ctx.offset {
+                    if ctx.ordered {
+                        ctx.order_gate.advance(batch_end);
+                    }
+                    continue;
+                }
+                if batch_start >= range_end {
+                    ctx.finished.store(true, Ordering::Relaxed);
+                    break;
+                }
+
+                let skip_in_batch = ctx.offset.saturating_sub(batch_start);
+                let take_count =
+                    (batch_size - skip_in_batch).min(range_end - batch_start - skip_in_batch);
+
+                let records = S::iter(&record_set)
+                    .skip(skip_in_batch)
+                    .take(take_count)
+                    .map(|r| r.map_err(Into::into));
+
+                records
+                    .process_results(|records| worker_processor.process_record_batch(records))??;
+
+                records_processed.fetch_add(take_count, Ordering::Relaxed);
+
+                if ctx.ordered {
+                    ctx.order_gate.wait_turn(batch_start);
+                }
+                worker_processor.on_batch_complete()?;
+                if ctx.ordered {
+                    ctx.order_gate.advance(batch_end);
+                }
+
+                // Resize *here*, after the order gate has been advanced past
+                // this batch. Retiring while the gate still expects this worker
+                // to advance it would stall every other worker behind a turn
+                // that never comes.
+                //
+                // The whole steady-state cost of a resizable pool: two relaxed
+                // loads, taking neither branch unless the target has moved.
+                if ctx.pool.try_release_slot() {
+                    retired = true;
+                    break;
+                }
+                while !ctx.finished.load(Ordering::Relaxed) && ctx.pool.try_claim_slot() {
+                    let fresh = ctx.template.lock().unwrap().clone();
+                    // Allocated on this thread rather than the new worker's, so
+                    // the allocation pattern matches the fixed path exactly.
+                    // Still only when a worker is really created, so nothing is
+                    // pre-allocated for a worker that never exists.
+                    let fresh_set = ctx.reader.new_record_set();
+                    spawn_worker(scope, &ctx, fresh, fresh_set, records_processed.clone());
+                }
+            }
+            // Retiring workers flush too: `on_thread_complete` is where a
+            // processor commits its per-thread state, and a worker that leaves
+            // mid-run has just as much to commit as one that reaches EOF.
+            worker_processor.on_thread_complete()?;
+            Ok(())
+        })();
+
+        if !retired {
+            ctx.pool.release_slot();
+        }
+        if let Err(e) = result {
+            if ctx.ordered {
+                ctx.order_gate.poison();
+            }
+            let mut slot = ctx.first_error.lock().unwrap();
+            if slot.is_none() {
+                *slot = Some(e);
+            }
+        }
+    });
 }
 
 #[cfg(test)]
@@ -799,6 +921,214 @@ mod tests {
             p5.count(),
             50,
             "multi-interleaved should process 50 record-groups"
+        );
+    }
+}
+
+#[cfg(test)]
+mod pool_tests {
+    use std::io::Cursor;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use crate::fastq;
+    use crate::parallel::{ParallelProcessor, ParallelReader, ProcessError, ThreadPool};
+    use crate::Record;
+
+    fn make_fastq(n: usize) -> Vec<u8> {
+        (0..n)
+            .flat_map(|i| format!("@seq{i}\nACGT\n+\nIIII\n").into_bytes())
+            .collect()
+    }
+
+    /// Deliberately keeps per-thread state and only publishes it in
+    /// `on_thread_complete`, exactly as a real processor does. That is what
+    /// makes it sensitive to *where* a new worker's clone comes from.
+    #[derive(Clone, Default)]
+    struct TallyProcessor {
+        total: Arc<AtomicUsize>,
+        threads_completed: Arc<AtomicUsize>,
+        local: usize,
+    }
+
+    impl<Rf: Record> ParallelProcessor<Rf> for TallyProcessor {
+        fn process_record(&mut self, _record: Rf) -> Result<(), ProcessError> {
+            self.local += 1;
+            Ok(())
+        }
+        fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
+            self.total.fetch_add(self.local, Ordering::Relaxed);
+            self.threads_completed.fetch_add(1, Ordering::Relaxed);
+            self.local = 0;
+            Ok(())
+        }
+    }
+
+    /// A pool that never resizes must behave exactly like a fixed count.
+    #[test]
+    fn a_fixed_pool_matches_a_fixed_thread_count() {
+        const N: usize = 5_000;
+        for threads in [1usize, 2, 8] {
+            let mut proc = TallyProcessor::default();
+            let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+            reader
+                .process_parallel_pool(&mut proc, &ThreadPool::new(threads))
+                .unwrap();
+            assert_eq!(proc.total.load(Ordering::Relaxed), N, "threads {threads}");
+        }
+    }
+
+    /// Regression: a worker leaving at EOF drops `live` below `target`, and
+    /// every remaining worker used to read that as "the pool is short" and
+    /// spawn a replacement, which hit EOF and did the same. That produced 3.1
+    /// million workers for a 32-thread run over an 8 M record file.
+    ///
+    /// The record count catches it; `threads_completed` catches it loudly.
+    #[test]
+    fn workers_leaving_at_eof_do_not_spawn_replacements() {
+        const N: usize = 20_000;
+        let mut proc = TallyProcessor::default();
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader
+            .process_parallel_pool(&mut proc, &ThreadPool::new(8))
+            .unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+        assert!(
+            proc.threads_completed.load(Ordering::Relaxed) <= 8,
+            "{} workers ran for an 8-worker pool: EOF is being mistaken for a \
+             shortfall and workers are respawning each other",
+            proc.threads_completed.load(Ordering::Relaxed)
+        );
+    }
+
+    /// Regression: new workers must be cloned from the caller's pristine
+    /// processor, never from a running one.
+    ///
+    /// `Clone` on a processor means "give me a fresh worker". Cloning a worker
+    /// mid-flight copies its accumulated `local`, and both copies then publish
+    /// it in `on_thread_complete` -- turning 8 M records into 791 billion.
+    #[test]
+    fn grown_workers_start_from_a_pristine_processor() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(1, 8);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let grower = std::thread::spawn(move || {
+            for n in 2..=8 {
+                std::thread::sleep(std::time::Duration::from_micros(200));
+                p2.set_threads(n);
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        grower.join().unwrap();
+
+        assert_eq!(
+            proc.total.load(Ordering::Relaxed),
+            N,
+            "records were counted more than once: a growing worker inherited \
+             another worker's partial tally"
+        );
+    }
+
+    /// Growth has to be reachable from a single worker, which means the
+    /// `num_threads == 1` sequential short-circuit must look at whether the
+    /// pool *can* grow, not at where it starts.
+    #[test]
+    fn a_pool_starting_at_one_can_still_grow() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(1, 4);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let grower = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_micros(500));
+            p2.set_threads(4);
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        grower.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// Shrinking must never retire the last worker.
+    ///
+    /// The assertion is that this test *finishes*. If the pool could empty
+    /// itself there would be no worker left to reach EOF, `thread::scope` would
+    /// wait on threads that no longer exist to be created, and the test would
+    /// hang rather than fail. Sampling `live()` instead would race the end of
+    /// the run, where zero is the correct answer.
+    #[test]
+    fn shrinking_always_leaves_one_worker() {
+        const N: usize = 400_000;
+        let pool = ThreadPool::with_max(8, 8);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let s2 = stop.clone();
+        let shrinker = std::thread::spawn(move || {
+            for n in (1..=8).rev() {
+                if s2.load(Ordering::Relaxed) {
+                    break;
+                }
+                p2.set_threads(n);
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        stop.store(true, Ordering::Relaxed);
+        shrinker.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// The property that has to hold under arbitrary resizing: every record is
+    /// processed exactly once, however many workers come and go.
+    #[test]
+    fn thread_churn_processes_every_record_exactly_once() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(4, 16);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let s2 = stop.clone();
+        let churner = std::thread::spawn(move || {
+            let mut n = 1;
+            while !s2.load(Ordering::Relaxed) {
+                n = if n >= 16 { 1 } else { n + 3 };
+                p2.set_threads(n);
+                std::thread::sleep(std::time::Duration::from_micros(100));
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        stop.store(true, Ordering::Relaxed);
+        churner.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// A pool never exceeds the ceiling it was built with.
+    #[test]
+    fn the_maximum_is_respected() {
+        let pool = ThreadPool::with_max(2, 4);
+        pool.set_threads(999);
+        assert_eq!(pool.threads(), 4);
+        pool.set_threads(0);
+        assert_eq!(
+            pool.threads(),
+            1,
+            "a pool must always want at least one worker"
         );
     }
 }


### PR DESCRIPTION
## What

Adds `ThreadPool`, a worker count that can change while a parallel run is in
flight, with pool-capable entry points on both `ParallelReader` and `Collection`.
Workers can be added or retired mid-run; at least one always remains, so a run
can always finish.

```rust
let pool = ThreadPool::with_max(4, 32);

// single reader
reader.process_parallel_pool(&mut processor, &pool)?;

// or a collection -- the target is a total across every reader
collection.process_parallel_paired_pool(&mut processor, &pool, None)?;

// from a supervisor thread, at any time
pool.set_threads(16);
```

`Collection` gains `process_parallel_pool`, `_paired_pool`, `_interleaved_pool`,
`_multi_pool` and `_multi_interleaved_pool`.

Based on `dev-0.5.0`.

## Why

`process_parallel*` fixes its worker count when it is called. That is the right
default, but it makes one decision unrecoverable: a caller splitting a fixed CPU
budget between paraseq's workers and some *other* consumer of the same budget has
to choose the split before reading a byte, and cannot correct it afterwards.

Our case is read mapping. We give paraseq N threads and a parallel gzip decoder
M, from one user-specified budget. Getting that split right up front turns out to
be genuinely hard — we measured a 2.6x spread across splits on one dataset, and
every static scheme we tried (fixed ratio, closed-form supply/demand model,
two-point measurement of achieved throughput) lands well off the optimum on at
least one workload. Being able to converge from live evidence instead removes the
need to predict it, and today paraseq is the half we cannot adjust.

This is additive: `process_parallel` and friends are untouched in behaviour, and
`ThreadPool::new(n)` is exactly a fixed count.

## Design notes

**Spawned on demand, not pre-spawned and parked.** Parking is simpler, but a
parked worker still needs its `RecordSet`, which is megabytes at a large batch
size and paid whether or not the worker ever runs. On-demand keeps the memory
proportional to workers that actually exist.

**A worker spawns its successors.** No coordinator thread and no polling
interval; the check happens between batches, where it is already amortised.

**Resizing is checked after the order gate is advanced.** Retiring while the gate
still expects this worker to advance past its batch would stall every worker
behind a turn that never comes. Retiring workers still run `on_thread_complete`,
since a worker leaving mid-run has as much per-thread state to commit as one
reaching EOF.

**One implementation, not two.** `process_parallel_generic_range` delegates to
the pool path with a fixed target, so the resizable path cannot drift from the
fixed one — every existing test exercises the new code.

**Concurrent readers get a `share`, not the pool.** A share keeps its own
live-worker count while reading the same target, so the caller's figure stays a
*total* across the run and one `set_threads` retargets every reader with nothing
to fan out. Handing every reader the same pool is not merely unfair: the first
would claim every slot, the rest would spawn no workers, and since only a running
worker spawns another, those readers would never start and their input would be
**silently skipped**. There is a test for exactly that, with fewer threads than
readers so every share has to floor at one.

## Overhead

Worst case for a per-batch check: uncompressed input, trivial per-record work,
maximum batch turnover, 64 threads. Best of 3–5, against `process_parallel` on
`dev-0.5.0`.

| run length | overhead |
|---:|---:|
| 0.30 s | +30% |
| 0.64 s | +1.25% |
| 2.2 s | **+0.04%** |

It is a slower startup ramp rather than a per-batch cost — a pool with a constant
target measured the same as the restructured fixed path (.365 s vs .361 s), so
the two relaxed loads per batch are not observable. **Callers with sub-second
runs at high thread counts should keep using `process_parallel`**, and the docs
say so.

Convergence after `set_threads` is bounded by batch service time, not by any
interval: 32 → 1 took ~161 ms consistently at `batch_size = 16384` with realistic
per-record work.

## Bugs found while building this

Each has a regression test, and **none was caught by the existing suite** — all
132 tests passed with every one of them present. I verified the new tests fail
when the corresponding fix is reverted.

1. **EOF spawn storm.** A worker leaving at EOF drops the live count below the
   target; every remaining worker reads that as a shortfall and spawns a
   replacement, which hits EOF and does the same. **3.1 million workers** for a
   32-thread run over an 8 M record file.

2. **Cloning a running worker.** New workers must come from the caller's pristine
   processor. `Clone` means "give me a fresh worker"; cloning mid-flight copies
   accumulated per-thread state, which `on_thread_complete` then publishes twice.
   An 8 M record file counted **791 billion** records. This one seems worth
   flagging beyond this PR — it is an easy assumption to make about `Clone` on a
   processor, and the failure is silent.

3. **Growth from one worker.** The `num_threads == 1` sequential short-circuit
   has to test whether the pool *can* grow, not where it starts.

4. **Worker counts were invisible to the pool's owner.** `live()` reports one
   share, and the pool a caller holds is the *parent* — whose own share never
   runs anything once a `Collection` splits it. So the obvious reading is zero
   for the entire run. Found by integration, not by these tests: a scheduler
   normalising work against "threads running" divided by the parent's count,
   measured every consumer as 0% idle however starved it was, and never moved a
   thread. `total_live` is maintained alongside the per-share counts, which stay
   authoritative for enforcing a share's own slice.

Mutation testing also removed code: a `claim_first_slot` guard I had added turned
out to be unreachable, because a share's live count starts at zero and
`share_target` floors at one, so the first claim always succeeds. No test could
distinguish its presence, so it went.

## Testing

- All 136 lib tests pass, including the 11 new ones.
- New tests cover: fixed-pool equivalence, EOF spawning, pristine cloning, growth
  from 1, the shrink floor, exact-once processing under continuous churn, the max
  bound, single and paired `Collection` dispatch, share/parent targeting, and
  the aggregate live count across shares.
- Churn test resizes 1↔16 every 100 µs for a whole run; record counts stay exact
  across ~300 spawn/retire cycles.
- `cargo clippy --lib` clean. The `--all-targets` example failures are
  pre-existing on `dev-0.5.0` here (they need system htslib/url deps).

## Open questions

- **Naming.** `ThreadPool` is descriptive but it does not own threads, it owns a
  *target*. `WorkerTarget` or `ThreadBudget` may be better.
- **Thread ids.** Dynamically spawned workers take ids from a monotonic counter,
  so ids are unique but not dense and not reused. Anything indexing per-thread
  storage by id would want a free-list instead; happy to add one.
- **Range variants.** The `*_range` methods do not have pool equivalents yet.
  They would be mechanical; say the word if you want them in this PR.
- Happy to split the three bug fixes into their own commits if you would rather
  land them independently of the feature.
