### PR TITLE
feat(parallel): resizable worker pool — fixed spawn set with parking (supersedes #75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cargo test --verbose
+      - name: Test pool feature
+        run: cargo test --verbose --features pool
 
   style:
     name: Style

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ htslib = ["dep:rust-htslib"]
 url = ["dep:reqwest", "dep:niffler"]
 ssh = ["dep:which"]
 gcs = ["dep:which"]
+pool = []
 
 [dev-dependencies]
 clap = { version = "4.5.40", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you're interested in reading more about it, I wrote a small [blog post](https
 - Supports URLs as input for FASTX files over HTTP and HTTPS (with `url` feature flag)
 - Supports SSH paths as inputs respecting system configuration (with `ssh` feature flag)
 - Supports Google Cloud Storage (GCS) URIs (with `gcs` feature flag). _requires [`gcloud`](https://cloud.google.com/sdk/docs/install) to be installed and authenticated_
+- Enables the experimental resizable `ThreadPool` and `PoolParallelReader` APIs (with the non-default `pool` feature flag). The existing fixed-thread APIs are unchanged when this feature is enabled.
 
 ## Usage
 

--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -7,7 +7,9 @@ use log::warn;
 use crate::parallel::multi::{InterleavedMultiReader, MultiReader};
 use crate::parallel::paired::{InterleavedPairedReader, PairedReader};
 use crate::parallel::reader::{range_to_offset_limit, SingleReader};
-use crate::parallel::single::{process_parallel_generic, process_parallel_generic_range};
+use crate::parallel::single::{
+    process_parallel_generic, process_parallel_generic_range, process_parallel_pool_range,
+};
 use crate::ProcessError;
 use crate::{fasta, fastq, Error, Record};
 
@@ -197,6 +199,127 @@ impl<R: io::Read + Send> Collection<R> {
                 }
             }
 
+            Ok(())
+        })
+    }
+
+    /// As [`Self::handle_single_readers`], but every reader running at the same
+    /// time gets a share of one resizable pool.
+    ///
+    /// Readers within a batch run concurrently, so the pool is split
+    /// `batch_size` ways: the target the caller sets stays a *total* across the
+    /// run rather than a per-reader figure, matching what `total_threads` means
+    /// on the fixed path.
+    fn handle_single_readers_pool<T, F>(
+        mut self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+        scope_fn: F,
+    ) -> crate::Result<()>
+    where
+        T: Clone + Send,
+        F: Fn(Reader<R>, &mut T, &crate::parallel::ThreadPool) -> crate::Result<()> + Send + Sync,
+    {
+        let total_readers = self.inner.len().max(1);
+        let total_threads = num_cpus::get().min(pool.threads().max(1));
+        let threads_per_reader = match threads_per_reader {
+            Some(num) => num.min(total_threads).max(1),
+            None => (total_threads / total_readers).max(1),
+        };
+        let batch_size = (total_threads / threads_per_reader).max(1);
+        let num_batches = total_readers.div_ceil(batch_size);
+
+        thread::scope(|scope| -> crate::Result<()> {
+            let scope_fn = &scope_fn;
+
+            for _batch_idx in 0..num_batches {
+                let mut batch = Vec::new();
+                let rbound = batch_size.min(self.inner.len());
+                batch.extend(self.inner.drain(..rbound));
+                // Split across the readers actually in this batch, not the
+                // nominal batch size, or the last short batch would under-use
+                // the pool.
+                let ways = batch.len().max(1);
+
+                let mut subhandles = Vec::new();
+                for reader in batch {
+                    let mut thread_proc = processor.clone();
+                    let share = pool.share(ways);
+                    subhandles.push(scope.spawn(move || -> crate::Result<()> {
+                        scope_fn(reader, &mut thread_proc, &share)?;
+                        Ok(())
+                    }));
+                }
+                for handle in subhandles {
+                    handle
+                        .join()
+                        .map_err(|_| crate::ProcessError::JoinError)??;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    /// As [`Self::handle_grouped_readers`], but every group running at the same
+    /// time gets a share of one resizable pool.
+    fn handle_grouped_readers_pool<T, F>(
+        mut self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_group: Option<usize>,
+        arity: usize,
+        scope_fn: F,
+    ) -> crate::Result<()>
+    where
+        T: Clone + Send,
+        F: Fn(Vec<Reader<R>>, &mut T, &crate::parallel::ThreadPool) -> crate::Result<()>
+            + Send
+            + Sync,
+    {
+        let total_groups = (self.inner.len() / arity).max(1);
+        let total_threads = num_cpus::get().min(pool.threads().max(1));
+        let threads_per_group = match threads_per_group {
+            Some(num) => num.min(total_threads).max(1),
+            None => {
+                if total_threads >= arity {
+                    (total_threads / total_groups).max(arity)
+                } else {
+                    (total_threads / total_groups).max(1)
+                }
+            }
+        };
+        let batch_size = (total_threads / threads_per_group).max(1);
+        let num_batches = total_groups.div_ceil(batch_size);
+
+        thread::scope(|scope| -> crate::Result<()> {
+            let scope_fn = &scope_fn;
+
+            for _batch_idx in 0..num_batches {
+                let mut batch = Vec::new();
+                let groups_in_batch =
+                    batch_size.min(total_groups.saturating_sub(_batch_idx * batch_size));
+                for _ in 0..groups_in_batch {
+                    let group: Vec<_> = self.inner.drain(..arity).collect();
+                    batch.push(group);
+                }
+                let ways = batch.len().max(1);
+
+                let mut subhandles = Vec::new();
+                for group in batch {
+                    let mut thread_proc = processor.clone();
+                    let share = pool.share(ways);
+                    subhandles.push(scope.spawn(move || -> crate::Result<()> {
+                        scope_fn(group, &mut thread_proc, &share)?;
+                        Ok(())
+                    }));
+                }
+                for handle in subhandles {
+                    handle
+                        .join()
+                        .map_err(|_| crate::ProcessError::JoinError)??;
+                }
+            }
             Ok(())
         })
     }
@@ -623,6 +746,134 @@ impl<R: io::Read + Send> Collection<R> {
                     threads,
                     start,
                     limit,
+                )
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel`], but the worker count may change while the
+    /// run is in flight. See [`crate::parallel::ThreadPool`].
+    ///
+    /// The pool's target is a total across every reader running concurrently,
+    /// not a per-reader count.
+    pub fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::ParallelProcessor<RefRecord<'a>>,
+    {
+        self.warn_if_mismatch(CollectionType::Single);
+        self.handle_single_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            |reader, proc, share| {
+                process_parallel_pool_range(SingleReader::new(reader), proc, share, 0, None)
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_paired`], with a resizable worker count.
+    pub fn process_parallel_paired_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::PairedParallelProcessor<RefRecord<'a>>,
+    {
+        self.warn_if_mismatch(CollectionType::Paired);
+        self.handle_grouped_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            2,
+            |mut readers, proc, share| {
+                let r1 = readers.remove(0);
+                let r2 = readers.remove(0);
+                process_parallel_pool_range(PairedReader::new(r1, r2), proc, share, 0, None)
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_interleaved`], with a resizable worker count.
+    pub fn process_parallel_interleaved_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::PairedParallelProcessor<RefRecord<'a>>,
+    {
+        self.warn_if_mismatch(CollectionType::Interleaved);
+        self.handle_single_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            |reader, proc, share| {
+                process_parallel_pool_range(
+                    InterleavedPairedReader::new(reader),
+                    proc,
+                    share,
+                    0,
+                    None,
+                )
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_multi`], with a resizable worker count.
+    pub fn process_parallel_multi_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::MultiParallelProcessor<RefRecord<'a>>,
+        Self: Sized,
+    {
+        let arity = self.get_arity_for_multi();
+        self.handle_grouped_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            arity,
+            |readers, proc, share| {
+                process_parallel_pool_range(MultiReader::new(readers), proc, share, 0, None)
+            },
+        )
+    }
+
+    /// As [`Self::process_parallel_multi_interleaved`], with a resizable worker
+    /// count.
+    pub fn process_parallel_multi_interleaved_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+        threads_per_reader: Option<usize>,
+    ) -> crate::Result<()>
+    where
+        T: for<'a> crate::prelude::MultiParallelProcessor<RefRecord<'a>>,
+        Self: Sized,
+    {
+        let arity = self.get_arity_for_interleaved_multi();
+        self.handle_single_readers_pool(
+            processor,
+            pool,
+            threads_per_reader,
+            move |reader, proc, share| {
+                process_parallel_pool_range(
+                    InterleavedMultiReader::new(reader, arity),
+                    proc,
+                    share,
+                    0,
+                    None,
                 )
             },
         )

--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -6,10 +6,10 @@ use log::warn;
 
 use crate::parallel::multi::{InterleavedMultiReader, MultiReader};
 use crate::parallel::paired::{InterleavedPairedReader, PairedReader};
+#[cfg(feature = "pool")]
+use crate::parallel::pool::process_parallel_pool_range;
 use crate::parallel::reader::{range_to_offset_limit, SingleReader};
-use crate::parallel::single::{
-    process_parallel_generic, process_parallel_generic_range, process_parallel_pool_range,
-};
+use crate::parallel::single::{process_parallel_generic, process_parallel_generic_range};
 use crate::ProcessError;
 use crate::{fasta, fastq, Error, Record};
 
@@ -210,6 +210,7 @@ impl<R: io::Read + Send> Collection<R> {
     /// `batch_size` ways: the target the caller sets stays a *total* across the
     /// run rather than a per-reader figure, matching what `total_threads` means
     /// on the fixed path.
+    #[cfg(feature = "pool")]
     fn handle_single_readers_pool<T, F>(
         mut self,
         processor: &mut T,
@@ -263,6 +264,7 @@ impl<R: io::Read + Send> Collection<R> {
 
     /// As [`Self::handle_grouped_readers`], but every group running at the same
     /// time gets a share of one resizable pool.
+    #[cfg(feature = "pool")]
     fn handle_grouped_readers_pool<T, F>(
         mut self,
         processor: &mut T,
@@ -756,6 +758,7 @@ impl<R: io::Read + Send> Collection<R> {
     ///
     /// The pool's target is a total across every reader running concurrently,
     /// not a per-reader count.
+    #[cfg(feature = "pool")]
     pub fn process_parallel_pool<T>(
         self,
         processor: &mut T,
@@ -777,6 +780,7 @@ impl<R: io::Read + Send> Collection<R> {
     }
 
     /// As [`Self::process_parallel_paired`], with a resizable worker count.
+    #[cfg(feature = "pool")]
     pub fn process_parallel_paired_pool<T>(
         self,
         processor: &mut T,
@@ -801,6 +805,7 @@ impl<R: io::Read + Send> Collection<R> {
     }
 
     /// As [`Self::process_parallel_interleaved`], with a resizable worker count.
+    #[cfg(feature = "pool")]
     pub fn process_parallel_interleaved_pool<T>(
         self,
         processor: &mut T,
@@ -828,6 +833,7 @@ impl<R: io::Read + Send> Collection<R> {
     }
 
     /// As [`Self::process_parallel_multi`], with a resizable worker count.
+    #[cfg(feature = "pool")]
     pub fn process_parallel_multi_pool<T>(
         self,
         processor: &mut T,
@@ -852,6 +858,7 @@ impl<R: io::Read + Send> Collection<R> {
 
     /// As [`Self::process_parallel_multi_interleaved`], with a resizable worker
     /// count.
+    #[cfg(feature = "pool")]
     pub fn process_parallel_multi_interleaved_pool<T>(
         self,
         processor: &mut T,

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -2,6 +2,7 @@ mod error;
 pub(crate) mod multi;
 mod ordered;
 pub(crate) mod paired;
+#[cfg(feature = "pool")]
 pub mod pool;
 mod processor;
 pub(crate) mod reader;
@@ -12,4 +13,7 @@ pub use ordered::Ordered;
 pub use processor::{MultiParallelProcessor, PairedParallelProcessor, ParallelProcessor};
 pub use reader::ParallelReader;
 
+#[cfg(feature = "pool")]
 pub use pool::ThreadPool;
+#[cfg(feature = "pool")]
+pub use reader::PoolParallelReader;

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -2,6 +2,7 @@ mod error;
 pub(crate) mod multi;
 mod ordered;
 pub(crate) mod paired;
+pub mod pool;
 mod processor;
 pub(crate) mod reader;
 pub(crate) mod single;
@@ -10,3 +11,5 @@ pub use error::{IntoProcessError, ProcessError, Result};
 pub use ordered::Ordered;
 pub use processor::{MultiParallelProcessor, PairedParallelProcessor, ParallelProcessor};
 pub use reader::ParallelReader;
+
+pub use pool::ThreadPool;

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -1,0 +1,145 @@
+//! A worker count that can change while a parallel run is in flight.
+//!
+//! # Why
+//!
+//! `process_parallel*` fixes its worker count when it is called. That is the
+//! right default, but it makes one class of decision unrecoverable: a caller
+//! that splits a fixed CPU budget between parsing/processing threads and some
+//! other consumer of the same budget — a parallel decompressor, say — has to
+//! choose the split before reading a byte, and cannot correct it afterwards.
+//!
+//! A [`ThreadPool`] lets that caller start somewhere reasonable and converge on
+//! evidence instead of committing up front.
+//!
+//! # Cost
+//!
+//! Workers are spawned on demand, not pre-spawned and parked. Pre-spawning is
+//! simpler but allocates a `RecordSet` per worker up front — at large batch
+//! sizes that is megabytes each, paid whether or not the worker ever runs.
+//!
+//! In exchange, a worker checks two relaxed atomics once per *batch* — not per
+//! record — and takes neither branch unless the target has actually moved.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct Inner {
+    /// Workers that should be running.
+    target: AtomicUsize,
+    /// Workers actually running. Only ever changed by a worker claiming or
+    /// releasing its own slot, so it cannot drift from reality.
+    live: AtomicUsize,
+    /// Hard ceiling. Bounds `target`, so a caller cannot ask for unbounded
+    /// threads by accident.
+    max: usize,
+}
+
+/// A shared, resizable worker count.
+///
+/// Cloning is cheap and every clone refers to the same pool.
+#[derive(Debug, Clone)]
+pub struct ThreadPool {
+    inner: Arc<Inner>,
+}
+
+impl ThreadPool {
+    /// A pool that never changes size — equivalent to passing `threads`
+    /// directly to `process_parallel*`.
+    pub fn new(threads: usize) -> Self {
+        Self::with_max(threads, threads)
+    }
+
+    /// A pool starting at `threads` that may later grow as far as `max`.
+    ///
+    /// `max` bounds growth only; it costs nothing until asked for, because
+    /// workers are spawned on demand.
+    pub fn with_max(threads: usize, max: usize) -> Self {
+        let max = max.max(1);
+        Self {
+            inner: Arc::new(Inner {
+                target: AtomicUsize::new(threads.clamp(1, max)),
+                live: AtomicUsize::new(0),
+                max,
+            }),
+        }
+    }
+
+    /// Change how many workers should be running.
+    ///
+    /// Takes effect within one batch per worker: growth spawns as running
+    /// workers notice the gap, and shrinking retires workers after they finish
+    /// the batch in hand. Never interrupts work in progress, so no record is
+    /// processed twice or dropped.
+    pub fn set_threads(&self, threads: usize) {
+        self.inner
+            .target
+            .store(threads.clamp(1, self.inner.max), Ordering::Relaxed);
+    }
+
+    /// The current target.
+    pub fn threads(&self) -> usize {
+        self.inner.target.load(Ordering::Relaxed)
+    }
+
+    /// Workers actually running now.
+    pub fn live(&self) -> usize {
+        self.inner.live.load(Ordering::Relaxed)
+    }
+
+    /// The ceiling set at construction.
+    pub fn max_threads(&self) -> usize {
+        self.inner.max
+    }
+
+    /// Claim a slot for a new worker, if the pool is short of its target.
+    ///
+    /// A CAS rather than a load-then-store because several workers may notice
+    /// the same shortfall at once, and two of them spawning for one slot would
+    /// overshoot the target.
+    pub(crate) fn try_claim_slot(&self) -> bool {
+        let mut live = self.inner.live.load(Ordering::Relaxed);
+        loop {
+            let target = self.inner.target.load(Ordering::Relaxed);
+            if live >= target || live >= self.inner.max {
+                return false;
+            }
+            match self.inner.live.compare_exchange_weak(
+                live,
+                live + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => live = actual,
+            }
+        }
+    }
+
+    /// Release this worker's slot if the pool is over its target.
+    ///
+    /// Symmetric to [`Self::try_claim_slot`]: the CAS is what stops every
+    /// surplus worker retiring at once when the target drops by one.
+    pub(crate) fn try_release_slot(&self) -> bool {
+        let mut live = self.inner.live.load(Ordering::Relaxed);
+        loop {
+            if live <= self.inner.target.load(Ordering::Relaxed) || live <= 1 {
+                return false;
+            }
+            match self.inner.live.compare_exchange_weak(
+                live,
+                live - 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => live = actual,
+            }
+        }
+    }
+
+    /// Release unconditionally, for a worker leaving because the input ended.
+    pub(crate) fn release_slot(&self) {
+        self.inner.live.fetch_sub(1, Ordering::AcqRel);
+    }
+}

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -32,6 +32,10 @@
 //! An active worker checks one relaxed atomic once per *batch* — not per
 //! record — and touches the mutex only when parking or being woken.
 
+mod processor;
+
+pub(crate) use processor::process_parallel_pool_range;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 
@@ -81,16 +85,16 @@ pub struct ThreadPool {
 }
 
 impl ThreadPool {
-    /// A pool that never changes size — equivalent to passing `threads`
-    /// directly to `process_parallel*`.
+    /// A pool that never changes size. Values below one are clamped to one.
     pub fn new(threads: usize) -> Self {
         Self::with_max(threads, threads)
     }
 
     /// A pool starting at `threads` that may later grow as far as `max`.
     ///
-    /// `max` bounds growth only; it costs nothing until asked for, because
-    /// workers are spawned on demand.
+    /// `max` bounds the fixed set of worker threads spawned for each parallel
+    /// run. Workers above the current target park without allocating a
+    /// `RecordSet` until the pool grows.
     pub fn with_max(threads: usize, max: usize) -> Self {
         let max = max.max(1);
         Self {

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -11,17 +11,29 @@
 //! A [`ThreadPool`] lets that caller start somewhere reasonable and converge on
 //! evidence instead of committing up front.
 //!
+//! # Design: a fixed spawn set, parked when over target
+//!
+//! Every worker the pool can ever run is spawned once, up front, with a stable
+//! index. A worker whose index is at or above the current target parks on a
+//! condvar at a batch boundary; growing the target wakes it. **No worker ever
+//! spawns another**, so the pool can never hold more workers than its ceiling
+//! — that bound is structural, not enforced by counting, and there is no
+//! spawn decision left to race on. (An earlier design spawned on demand when
+//! running workers observed a shortfall; distinguishing "a peer left at EOF"
+//! from "the pool is short" from a worker's viewpoint is inherently racy, and
+//! under a small input the observed worker count could exceed the ceiling.)
+//!
+//! A parked worker holds no `RecordSet` — workers allocate theirs lazily on
+//! first activation — so a worker that never runs costs one OS thread and
+//! nothing else.
+//!
 //! # Cost
 //!
-//! Workers are spawned on demand, not pre-spawned and parked. Pre-spawning is
-//! simpler but allocates a `RecordSet` per worker up front — at large batch
-//! sizes that is megabytes each, paid whether or not the worker ever runs.
-//!
-//! In exchange, a worker checks two relaxed atomics once per *batch* — not per
-//! record — and takes neither branch unless the target has actually moved.
+//! An active worker checks one relaxed atomic once per *batch* — not per
+//! record — and touches the mutex only when parking or being woken.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
 
 #[derive(Debug)]
 struct Inner {
@@ -32,15 +44,24 @@ struct Inner {
     target: AtomicUsize,
     /// Hard ceiling on `target`.
     max: usize,
-    /// Workers live across *every* share of this pool.
+    /// Workers active across *every* share of this pool.
     ///
-    /// Each share tracks its own count to enforce its own slice, but a caller
-    /// supervising the whole run needs the total — and summing shares is not
-    /// possible from outside, because a share is handed to a worker thread and
-    /// never surfaced. Without this, an external scheduler normalising work
-    /// against "threads running" divides by the parent's count, which stays at
-    /// zero for the entire run.
+    /// Purely telemetry: an external supervisor normalising work against
+    /// "threads running" reads this. Nothing in the pool decides anything from
+    /// it — activation is by stable worker index against the target, so this
+    /// count can lag reality by a batch without consequence.
     total_live: AtomicUsize,
+    /// Orders `set_threads` against a worker's check-then-park.
+    ///
+    /// The predicate a parked worker waits on reads atomics, but the *check
+    /// then wait* must happen under this lock, and every state change that
+    /// could unpark someone must notify while holding it. Changing state and
+    /// notifying without the lock loses the wakeup when the change lands
+    /// between a worker's check and its park — a bug class we have hit
+    /// elsewhere, and one that a test with any other periodic notifier will
+    /// never catch, because the next notify repairs the loss.
+    gate: Mutex<()>,
+    signal: Condvar,
 }
 
 /// A shared, resizable worker count.
@@ -77,6 +98,8 @@ impl ThreadPool {
                 target: AtomicUsize::new(threads.clamp(1, max)),
                 max,
                 total_live: AtomicUsize::new(0),
+                gate: Mutex::new(()),
+                signal: Condvar::new(),
             }),
             live: Arc::new(AtomicUsize::new(0)),
             divisor: 1,
@@ -89,11 +112,9 @@ impl ThreadPool {
     /// `set_threads` on any of them retargets all of them at once. The target
     /// is a total: `ways` shares of a 32-thread pool run 8 workers each.
     ///
-    /// Sharing rather than handing the same pool to every reader is deliberate.
-    /// A single pool would let the first reader claim every slot, leaving the
-    /// rest to spawn nothing — and since workers are only spawned *by* running
-    /// workers, those readers would never start and their input would be
-    /// silently skipped.
+    /// Sharing rather than handing the same pool to every reader is deliberate:
+    /// each share spawns and parks its own slice of workers against its own
+    /// slice of the target, so no reader can starve another of workers.
     pub fn share(&self, ways: usize) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
@@ -104,14 +125,17 @@ impl ThreadPool {
 
     /// Change how many workers should be running, across every share.
     ///
-    /// Takes effect within one batch per worker: growth spawns as running
-    /// workers notice the gap, and shrinking retires workers after they finish
-    /// the batch in hand. Never interrupts work in progress, so no record is
-    /// processed twice or dropped.
+    /// Takes effect within one batch per worker: growth wakes parked workers,
+    /// and shrinking parks workers after they finish the batch in hand. Never
+    /// interrupts work in progress, so no record is processed twice or
+    /// dropped.
     pub fn set_threads(&self, threads: usize) {
         self.inner
             .target
-            .store(threads.clamp(1, self.inner.max), Ordering::Relaxed);
+            .store(threads.clamp(1, self.inner.max), Ordering::Release);
+        // Lock-then-notify: see `Inner::gate` for why the lock is not optional.
+        let _gate = self.inner.gate.lock().unwrap();
+        self.inner.signal.notify_all();
     }
 
     /// The current target, across every share.
@@ -148,59 +172,34 @@ impl ThreadPool {
         (self.inner.max / self.divisor).max(1)
     }
 
-    /// Claim a slot for a new worker, if the pool is short of its target.
+    /// Block until `active()` is true, re-checking under the pool's gate.
     ///
-    /// A CAS rather than a load-then-store because several workers may notice
-    /// the same shortfall at once, and two of them spawning for one slot would
-    /// overshoot the target.
-    pub(crate) fn try_claim_slot(&self) -> bool {
-        let mut live = self.live.load(Ordering::Relaxed);
-        loop {
-            if live >= self.share_target() || live >= self.share_max() {
-                return false;
-            }
-            match self.live.compare_exchange_weak(
-                live,
-                live + 1,
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => {
-                    self.inner.total_live.fetch_add(1, Ordering::AcqRel);
-                    return true;
-                }
-                Err(actual) => live = actual,
-            }
+    /// The closure is evaluated with the gate held; any state it reads must be
+    /// changed only in combination with a locked notify (see [`Inner::gate`]).
+    pub(crate) fn park_until(&self, mut active: impl FnMut() -> bool) {
+        let mut gate = self.inner.gate.lock().unwrap();
+        while !active() {
+            gate = self.inner.signal.wait(gate).unwrap();
         }
     }
 
-    /// Release this worker's slot if the pool is over its target.
+    /// Wake every parked worker so it re-checks its predicate.
     ///
-    /// Symmetric to [`Self::try_claim_slot`]: the CAS is what stops every
-    /// surplus worker retiring at once when the target drops by one.
-    pub(crate) fn try_release_slot(&self) -> bool {
-        let mut live = self.live.load(Ordering::Relaxed);
-        loop {
-            if live <= self.share_target() || live <= 1 {
-                return false;
-            }
-            match self.live.compare_exchange_weak(
-                live,
-                live - 1,
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => {
-                    self.inner.total_live.fetch_sub(1, Ordering::AcqRel);
-                    return true;
-                }
-                Err(actual) => live = actual,
-            }
-        }
+    /// For state changes made outside the pool (end of input, a poisoned
+    /// order gate) that must be able to unpark workers.
+    pub(crate) fn wake_all(&self) {
+        let _gate = self.inner.gate.lock().unwrap();
+        self.inner.signal.notify_all();
     }
 
-    /// Release unconditionally, for a worker leaving because the input ended.
-    pub(crate) fn release_slot(&self) {
+    /// Record this worker as active. Telemetry only.
+    pub(crate) fn enter_live(&self) {
+        self.live.fetch_add(1, Ordering::AcqRel);
+        self.inner.total_live.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Record this worker as parked or exited. Telemetry only.
+    pub(crate) fn exit_live(&self) {
         self.live.fetch_sub(1, Ordering::AcqRel);
         self.inner.total_live.fetch_sub(1, Ordering::AcqRel);
     }

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -32,6 +32,15 @@ struct Inner {
     target: AtomicUsize,
     /// Hard ceiling on `target`.
     max: usize,
+    /// Workers live across *every* share of this pool.
+    ///
+    /// Each share tracks its own count to enforce its own slice, but a caller
+    /// supervising the whole run needs the total — and summing shares is not
+    /// possible from outside, because a share is handed to a worker thread and
+    /// never surfaced. Without this, an external scheduler normalising work
+    /// against "threads running" divides by the parent's count, which stays at
+    /// zero for the entire run.
+    total_live: AtomicUsize,
 }
 
 /// A shared, resizable worker count.
@@ -67,6 +76,7 @@ impl ThreadPool {
             inner: Arc::new(Inner {
                 target: AtomicUsize::new(threads.clamp(1, max)),
                 max,
+                total_live: AtomicUsize::new(0),
             }),
             live: Arc::new(AtomicUsize::new(0)),
             divisor: 1,
@@ -114,6 +124,15 @@ impl ThreadPool {
         self.live.load(Ordering::Relaxed)
     }
 
+    /// Workers running across every share of this pool.
+    ///
+    /// This is the figure a supervisor wants. [`Self::live`] reports only the
+    /// share it is called on, and the pool a caller holds is the *parent*, whose
+    /// own share never runs anything when a `Collection` splits it.
+    pub fn total_live(&self) -> usize {
+        self.inner.total_live.load(Ordering::Relaxed)
+    }
+
     /// The ceiling set at construction, across every share.
     pub fn max_threads(&self) -> usize {
         self.inner.max
@@ -146,7 +165,10 @@ impl ThreadPool {
                 Ordering::AcqRel,
                 Ordering::Relaxed,
             ) {
-                Ok(_) => return true,
+                Ok(_) => {
+                    self.inner.total_live.fetch_add(1, Ordering::AcqRel);
+                    return true;
+                }
                 Err(actual) => live = actual,
             }
         }
@@ -168,7 +190,10 @@ impl ThreadPool {
                 Ordering::AcqRel,
                 Ordering::Relaxed,
             ) {
-                Ok(_) => return true,
+                Ok(_) => {
+                    self.inner.total_live.fetch_sub(1, Ordering::AcqRel);
+                    return true;
+                }
                 Err(actual) => live = actual,
             }
         }
@@ -177,5 +202,6 @@ impl ThreadPool {
     /// Release unconditionally, for a worker leaving because the input ended.
     pub(crate) fn release_slot(&self) {
         self.live.fetch_sub(1, Ordering::AcqRel);
+        self.inner.total_live.fetch_sub(1, Ordering::AcqRel);
     }
 }

--- a/src/parallel/pool.rs
+++ b/src/parallel/pool.rs
@@ -25,22 +25,29 @@ use std::sync::Arc;
 
 #[derive(Debug)]
 struct Inner {
-    /// Workers that should be running.
+    /// Workers that should be running, across every share of this pool.
+    ///
+    /// Shared by all shares so that one `set_threads` reaches every reader a
+    /// `Collection` is driving, without anything having to fan the change out.
     target: AtomicUsize,
-    /// Workers actually running. Only ever changed by a worker claiming or
-    /// releasing its own slot, so it cannot drift from reality.
-    live: AtomicUsize,
-    /// Hard ceiling. Bounds `target`, so a caller cannot ask for unbounded
-    /// threads by accident.
+    /// Hard ceiling on `target`.
     max: usize,
 }
 
 /// A shared, resizable worker count.
 ///
-/// Cloning is cheap and every clone refers to the same pool.
+/// Cloning is cheap and every clone refers to the same pool. A `Collection`
+/// driving several readers at once gives each one a [`share`](Self::share) of
+/// the same pool, so the target the caller sets is a *total* rather than a
+/// per-reader figure.
 #[derive(Debug, Clone)]
 pub struct ThreadPool {
     inner: Arc<Inner>,
+    /// Workers running in *this* share. Only ever changed by a worker claiming
+    /// or releasing its own slot, so it cannot drift from reality.
+    live: Arc<AtomicUsize>,
+    /// How many shares divide `inner.target`. One for an unshared pool.
+    divisor: usize,
 }
 
 impl ThreadPool {
@@ -59,13 +66,33 @@ impl ThreadPool {
         Self {
             inner: Arc::new(Inner {
                 target: AtomicUsize::new(threads.clamp(1, max)),
-                live: AtomicUsize::new(0),
                 max,
             }),
+            live: Arc::new(AtomicUsize::new(0)),
+            divisor: 1,
         }
     }
 
-    /// Change how many workers should be running.
+    /// A view of this pool for one of `ways` concurrent consumers.
+    ///
+    /// Each share tracks its own live workers but reads the same target, so a
+    /// `set_threads` on any of them retargets all of them at once. The target
+    /// is a total: `ways` shares of a 32-thread pool run 8 workers each.
+    ///
+    /// Sharing rather than handing the same pool to every reader is deliberate.
+    /// A single pool would let the first reader claim every slot, leaving the
+    /// rest to spawn nothing — and since workers are only spawned *by* running
+    /// workers, those readers would never start and their input would be
+    /// silently skipped.
+    pub fn share(&self, ways: usize) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            live: Arc::new(AtomicUsize::new(0)),
+            divisor: self.divisor.saturating_mul(ways.max(1)).max(1),
+        }
+    }
+
+    /// Change how many workers should be running, across every share.
     ///
     /// Takes effect within one batch per worker: growth spawns as running
     /// workers notice the gap, and shrinking retires workers after they finish
@@ -77,19 +104,29 @@ impl ThreadPool {
             .store(threads.clamp(1, self.inner.max), Ordering::Relaxed);
     }
 
-    /// The current target.
+    /// The current target, across every share.
     pub fn threads(&self) -> usize {
         self.inner.target.load(Ordering::Relaxed)
     }
 
-    /// Workers actually running now.
+    /// Workers running in this share.
     pub fn live(&self) -> usize {
-        self.inner.live.load(Ordering::Relaxed)
+        self.live.load(Ordering::Relaxed)
     }
 
-    /// The ceiling set at construction.
+    /// The ceiling set at construction, across every share.
     pub fn max_threads(&self) -> usize {
         self.inner.max
+    }
+
+    /// This share's slice of the target, never below one.
+    pub(crate) fn share_target(&self) -> usize {
+        (self.threads() / self.divisor).max(1)
+    }
+
+    /// This share's slice of the ceiling, never below one.
+    pub(crate) fn share_max(&self) -> usize {
+        (self.inner.max / self.divisor).max(1)
     }
 
     /// Claim a slot for a new worker, if the pool is short of its target.
@@ -98,13 +135,12 @@ impl ThreadPool {
     /// the same shortfall at once, and two of them spawning for one slot would
     /// overshoot the target.
     pub(crate) fn try_claim_slot(&self) -> bool {
-        let mut live = self.inner.live.load(Ordering::Relaxed);
+        let mut live = self.live.load(Ordering::Relaxed);
         loop {
-            let target = self.inner.target.load(Ordering::Relaxed);
-            if live >= target || live >= self.inner.max {
+            if live >= self.share_target() || live >= self.share_max() {
                 return false;
             }
-            match self.inner.live.compare_exchange_weak(
+            match self.live.compare_exchange_weak(
                 live,
                 live + 1,
                 Ordering::AcqRel,
@@ -121,12 +157,12 @@ impl ThreadPool {
     /// Symmetric to [`Self::try_claim_slot`]: the CAS is what stops every
     /// surplus worker retiring at once when the target drops by one.
     pub(crate) fn try_release_slot(&self) -> bool {
-        let mut live = self.inner.live.load(Ordering::Relaxed);
+        let mut live = self.live.load(Ordering::Relaxed);
         loop {
-            if live <= self.inner.target.load(Ordering::Relaxed) || live <= 1 {
+            if live <= self.share_target() || live <= 1 {
                 return false;
             }
-            match self.inner.live.compare_exchange_weak(
+            match self.live.compare_exchange_weak(
                 live,
                 live - 1,
                 Ordering::AcqRel,
@@ -140,6 +176,6 @@ impl ThreadPool {
 
     /// Release unconditionally, for a worker leaving because the input ended.
     pub(crate) fn release_slot(&self) {
-        self.inner.live.fetch_sub(1, Ordering::AcqRel);
+        self.live.fetch_sub(1, Ordering::AcqRel);
     }
 }

--- a/src/parallel/pool/processor.rs
+++ b/src/parallel/pool/processor.rs
@@ -1,0 +1,615 @@
+use itertools::Itertools;
+
+use crate::parallel::ordered::OrderGate;
+use crate::parallel::processor::GenericProcessor;
+use crate::parallel::single::{process_parallel_generic_range, MTGenericReader};
+use crate::parallel::{error::Result, ProcessError};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+/// As [`process_parallel_generic_range`], but the worker count may change while
+/// the run is in flight. See [`crate::parallel::ThreadPool`].
+pub(crate) fn process_parallel_pool_range<S: MTGenericReader, T>(
+    mut reader: S,
+    processor: &mut T,
+    pool: &crate::parallel::ThreadPool,
+    offset: usize,
+    limit: Option<usize>,
+) -> Result<()>
+where
+    T: for<'a> GenericProcessor<S::RefRecord<'a>>,
+{
+    let mut num_threads = pool.share_target();
+    if num_threads == 0 {
+        num_threads = num_cpus::get();
+    }
+    // Only when the pool can never grow. A pool that *starts* at one worker but
+    // may be resized has to take the parallel path anyway, or it could never
+    // honour a later `set_threads` -- there is no pool in the sequential path.
+    if num_threads == 1 && pool.share_max() == 1 {
+        return process_parallel_generic_range(reader, processor, 1, offset, limit);
+    }
+
+    reader.set_num_threads(num_threads).map_err(Into::into)?;
+
+    let records_processed = Arc::new(AtomicUsize::default());
+    let order_gate = Arc::new(OrderGate::new());
+    let ordered = processor.requires_ordering();
+
+    let first_error: Mutex<Option<ProcessError>> = Mutex::new(None);
+    // Set at end of input (or when the record limit is reached). Parked
+    // workers wait on the pool's gate with this in their predicate, so setting
+    // it must be paired with `pool.wake_all()` or they would sleep forever.
+    let finished = AtomicBool::new(false);
+
+    thread::scope(|scope| -> Result<()> {
+        let reader = &reader;
+        let ctx = WorkerCtx {
+            reader,
+            pool,
+            first_error: &first_error,
+            finished: &finished,
+            order_gate: &order_gate,
+            ordered,
+            offset,
+            limit,
+        };
+
+        // The whole spawn set, once, each worker with a stable index. A worker
+        // whose index is at or above the target parks immediately (allocating
+        // nothing); growth wakes it. Because nothing ever spawns after this
+        // loop, the worker count is bounded by construction -- there is no
+        // claim/release accounting to race against EOF.
+        for worker_id in 0..pool.share_max() {
+            spawn_worker(
+                scope,
+                &ctx,
+                worker_id,
+                processor.clone(),
+                records_processed.clone(),
+            );
+        }
+        Ok(())
+    })?;
+
+    match first_error.into_inner().unwrap_or(None) {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Everything a worker needs that is identical for every worker.
+///
+/// Grouped so that spawning one takes three arguments rather than a dozen, and
+/// so a worker can hand the same context to a successor.
+struct WorkerCtx<'env, S> {
+    reader: &'env S,
+    pool: &'env crate::parallel::ThreadPool,
+    first_error: &'env Mutex<Option<ProcessError>>,
+    finished: &'env AtomicBool,
+    order_gate: &'env Arc<OrderGate>,
+    ordered: bool,
+    offset: usize,
+    limit: Option<usize>,
+}
+
+impl<S> Clone for WorkerCtx<'_, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<S> Copy for WorkerCtx<'_, S> {}
+
+/// Run one worker of the fixed spawn set.
+///
+/// The worker parks when its index is at or above the target and resumes when
+/// growth brings the target back over it. It allocates its `RecordSet` lazily,
+/// on first activation, so a worker that never runs holds no batch memory.
+/// Parking happens only at a batch boundary, after the order gate has been
+/// advanced past the batch in hand, so ordered mode never waits on a turn a
+/// parked worker owes.
+fn spawn_worker<'scope, 'env, S, T>(
+    scope: &'scope thread::Scope<'scope, 'env>,
+    ctx: &WorkerCtx<'env, S>,
+    worker_id: usize,
+    mut worker_processor: T,
+    records_processed: Arc<AtomicUsize>,
+) where
+    S: MTGenericReader + Sync + 'env,
+    T: for<'a> GenericProcessor<S::RefRecord<'a>> + Send + 'env,
+{
+    let ctx = *ctx;
+    scope.spawn(move || {
+        let mut record_set: Option<S::RecordSet> = None;
+        let mut active = false;
+
+        // As in the fixed path: run the body in a closure so any error can
+        // poison the order gate before propagating, rather than deadlocking
+        // workers waiting on a batch that will never complete.
+        let result: Result<()> = (|| {
+            worker_processor.set_thread_id(worker_id);
+
+            loop {
+                if ctx.finished.load(Ordering::Acquire) {
+                    break;
+                }
+                // Over target: park until growth or end of input. The
+                // predicate is re-checked under the pool's gate, and both
+                // `set_threads` and the finished path notify under that same
+                // gate, so the wakeup cannot be lost.
+                if worker_id >= ctx.pool.share_target() {
+                    if active {
+                        ctx.pool.exit_live();
+                        active = false;
+                    }
+                    // Parked memory is proportional to *active* workers: the
+                    // batch in this set was fully processed and the order gate
+                    // advanced past it before we got here, so its contents are
+                    // dead -- drop the buffers rather than hold megabytes idle
+                    // for however long the pool stays shrunk. Re-activation
+                    // re-allocates; resizes happen on controller cadences
+                    // (hundreds of ms), so the churn is noise.
+                    record_set = None;
+                    ctx.pool.park_until(|| {
+                        worker_id < ctx.pool.share_target() || ctx.finished.load(Ordering::Acquire)
+                    });
+                    continue;
+                }
+                if !active {
+                    ctx.pool.enter_live();
+                    active = true;
+                }
+                let record_set = record_set.get_or_insert_with(|| ctx.reader.new_record_set());
+
+                if let Some(lim) = ctx.limit {
+                    if records_processed.load(Ordering::Relaxed) >= lim {
+                        ctx.finished.store(true, Ordering::Release);
+                        ctx.pool.wake_all();
+                        break;
+                    }
+                }
+
+                let Some((batch_start, batch_end)) =
+                    ctx.reader.fill(record_set).map_err(Into::into)?
+                else {
+                    ctx.finished.store(true, Ordering::Release);
+                    ctx.pool.wake_all();
+                    break; // EOF
+                };
+                let batch_size = batch_end - batch_start;
+                let range_end = ctx.limit.map(|lim| ctx.offset + lim).unwrap_or(usize::MAX);
+
+                if batch_end <= ctx.offset {
+                    if ctx.ordered {
+                        ctx.order_gate.advance(batch_end);
+                    }
+                    continue;
+                }
+                if batch_start >= range_end {
+                    ctx.finished.store(true, Ordering::Release);
+                    ctx.pool.wake_all();
+                    break;
+                }
+
+                let skip_in_batch = ctx.offset.saturating_sub(batch_start);
+                let take_count =
+                    (batch_size - skip_in_batch).min(range_end - batch_start - skip_in_batch);
+
+                let records = S::iter(record_set)
+                    .skip(skip_in_batch)
+                    .take(take_count)
+                    .map(|r| r.map_err(Into::into));
+
+                records
+                    .process_results(|records| worker_processor.process_record_batch(records))??;
+
+                records_processed.fetch_add(take_count, Ordering::Relaxed);
+
+                if ctx.ordered {
+                    ctx.order_gate.wait_turn(batch_start);
+                }
+                worker_processor.on_batch_complete()?;
+                if ctx.ordered {
+                    ctx.order_gate.advance(batch_end);
+                }
+            }
+            worker_processor.on_thread_complete()?;
+            Ok(())
+        })();
+
+        if active {
+            ctx.pool.exit_live();
+        }
+        if let Err(e) = result {
+            if ctx.ordered {
+                ctx.order_gate.poison();
+            }
+            // An erroring worker also ends the run for its peers -- parked
+            // workers in particular, who would otherwise sleep until a wakeup
+            // that is never coming once their siblings have stopped filling.
+            ctx.finished.store(true, Ordering::Release);
+            ctx.pool.wake_all();
+            let mut slot = ctx.first_error.lock().unwrap();
+            if slot.is_none() {
+                *slot = Some(e);
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use crate::fastq;
+    use crate::parallel::{ParallelProcessor, PoolParallelReader, ProcessError, ThreadPool};
+    use crate::Record;
+
+    fn make_fastq(n: usize) -> Vec<u8> {
+        (0..n)
+            .flat_map(|i| format!("@seq{i}\nACGT\n+\nIIII\n").into_bytes())
+            .collect()
+    }
+
+    /// Deliberately keeps per-thread state and only publishes it in
+    /// `on_thread_complete`, exactly as a real processor does. That is what
+    /// makes it sensitive to *where* a new worker's clone comes from.
+    #[derive(Clone, Default)]
+    struct TallyProcessor {
+        total: Arc<AtomicUsize>,
+        threads_completed: Arc<AtomicUsize>,
+        local: usize,
+    }
+
+    impl<Rf: Record> ParallelProcessor<Rf> for TallyProcessor {
+        fn process_record(&mut self, _record: Rf) -> Result<(), ProcessError> {
+            self.local += 1;
+            Ok(())
+        }
+        fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
+            self.total.fetch_add(self.local, Ordering::Relaxed);
+            self.threads_completed.fetch_add(1, Ordering::Relaxed);
+            self.local = 0;
+            Ok(())
+        }
+    }
+
+    /// A pool that never resizes must behave exactly like a fixed count.
+    #[test]
+    fn a_fixed_pool_matches_a_fixed_thread_count() {
+        const N: usize = 5_000;
+        for threads in [1usize, 2, 8] {
+            let mut proc = TallyProcessor::default();
+            let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+            reader
+                .process_parallel_pool(&mut proc, &ThreadPool::new(threads))
+                .unwrap();
+            assert_eq!(proc.total.load(Ordering::Relaxed), N, "threads {threads}");
+        }
+    }
+
+    /// Regression: a worker leaving at EOF used to drop `live` below
+    /// `target`, every remaining worker read that as "the pool is short" and
+    /// spawned a replacement, which hit EOF and did the same — 3.1 million
+    /// workers for a 32-thread run over an 8 M record file. Even with an EOF
+    /// guard, a small input could race 9 concurrent workers into an 8-worker
+    /// pool, because peers made spawn decisions from observed live counts.
+    ///
+    /// The fixed spawn set makes the bound structural: workers are spawned
+    /// once with stable indices and nothing spawns afterwards, so there is no
+    /// decision left to race on. The input here is deliberately tiny (the size
+    /// at which the old design failed deterministically), the run is repeated,
+    /// and *concurrency* is measured directly rather than inferred from
+    /// completion counts.
+    #[test]
+    fn worker_concurrency_is_bounded_by_construction() {
+        const N: usize = 200;
+        #[derive(Clone, Default)]
+        struct ConcurrencyProbe {
+            current: Arc<AtomicUsize>,
+            peak: Arc<AtomicUsize>,
+            total: Arc<AtomicUsize>,
+        }
+        impl<Rf: crate::Record> crate::parallel::ParallelProcessor<Rf> for ConcurrencyProbe {
+            fn process_record(&mut self, _r: Rf) -> Result<(), ProcessError> {
+                let now = self.current.fetch_add(1, Ordering::AcqRel) + 1;
+                self.peak.fetch_max(now, Ordering::AcqRel);
+                self.total.fetch_add(1, Ordering::Relaxed);
+                self.current.fetch_sub(1, Ordering::AcqRel);
+                Ok(())
+            }
+        }
+
+        for _ in 0..25 {
+            let proc_template = ConcurrencyProbe::default();
+            let mut proc = proc_template.clone();
+            let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+            reader
+                .process_parallel_pool(&mut proc, &ThreadPool::new(8))
+                .unwrap();
+            assert_eq!(proc_template.total.load(Ordering::Relaxed), N);
+            let peak = proc_template.peak.load(Ordering::Relaxed);
+            assert!(
+                peak <= 8,
+                "{peak} concurrent workers in an 8-worker pool: the spawn-set \
+                 bound has been broken"
+            );
+        }
+    }
+
+    /// Regression: new workers must be cloned from the caller's pristine
+    /// processor, never from a running one.
+    ///
+    /// `Clone` on a processor means "give me a fresh worker". Cloning a worker
+    /// mid-flight copies its accumulated `local`, and both copies then publish
+    /// it in `on_thread_complete` -- turning 8 M records into 791 billion.
+    #[test]
+    fn grown_workers_start_from_a_pristine_processor() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(1, 8);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let grower = std::thread::spawn(move || {
+            for n in 2..=8 {
+                std::thread::sleep(std::time::Duration::from_micros(200));
+                p2.set_threads(n);
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        grower.join().unwrap();
+
+        assert_eq!(
+            proc.total.load(Ordering::Relaxed),
+            N,
+            "records were counted more than once: a growing worker inherited \
+             another worker's partial tally"
+        );
+    }
+
+    /// Growth has to be reachable from a single worker, which means the
+    /// `num_threads == 1` sequential short-circuit must look at whether the
+    /// pool *can* grow, not at where it starts.
+    #[test]
+    fn a_pool_starting_at_one_can_still_grow() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(1, 4);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let grower = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_micros(500));
+            p2.set_threads(4);
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        grower.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// Shrinking must never retire the last worker.
+    ///
+    /// The assertion is that this test *finishes*. If the pool could empty
+    /// itself there would be no worker left to reach EOF, `thread::scope` would
+    /// wait on threads that no longer exist to be created, and the test would
+    /// hang rather than fail. Sampling `live()` instead would race the end of
+    /// the run, where zero is the correct answer.
+    #[test]
+    fn shrinking_always_leaves_one_worker() {
+        const N: usize = 400_000;
+        let pool = ThreadPool::with_max(8, 8);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let s2 = stop.clone();
+        let shrinker = std::thread::spawn(move || {
+            for n in (1..=8).rev() {
+                if s2.load(Ordering::Relaxed) {
+                    break;
+                }
+                p2.set_threads(n);
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        stop.store(true, Ordering::Relaxed);
+        shrinker.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// The property that has to hold under arbitrary resizing: every record is
+    /// processed exactly once, however many workers come and go.
+    #[test]
+    fn thread_churn_processes_every_record_exactly_once() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(4, 16);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let s2 = stop.clone();
+        let churner = std::thread::spawn(move || {
+            let mut n = 1;
+            while !s2.load(Ordering::Relaxed) {
+                n = if n >= 16 { 1 } else { n + 3 };
+                p2.set_threads(n);
+                std::thread::sleep(std::time::Duration::from_micros(100));
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        stop.store(true, Ordering::Relaxed);
+        churner.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// A supervisor outside the run needs the aggregate live count.
+    ///
+    /// `live()` reports one share, and the pool a caller holds is the *parent*,
+    /// whose own share never runs anything once a `Collection` splits it — so the
+    /// obvious reading is zero for the whole run. An external scheduler normalising
+    /// work against "threads running" then divides by nothing and concludes the
+    /// consumer is never busy.
+    #[test]
+    fn total_live_counts_workers_across_every_share() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(8, 8);
+        let observer = pool.clone();
+        let seen = Arc::new(AtomicUsize::new(0));
+        let s2 = Arc::clone(&seen);
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let st2 = Arc::clone(&stop);
+        let watcher = std::thread::spawn(move || {
+            while !st2.load(Ordering::Relaxed) {
+                s2.fetch_max(observer.total_live(), Ordering::Relaxed);
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+        });
+
+        let mut proc = TallyProcessor::default();
+        let inner: Vec<_> = (0..4)
+            .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+            .collect();
+        Collection::new(inner, CollectionType::Single)
+            .unwrap()
+            .process_parallel_pool(&mut proc, &pool, None)
+            .unwrap();
+        stop.store(true, Ordering::Relaxed);
+        watcher.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N * 4);
+        assert!(
+            seen.load(Ordering::Relaxed) > 1,
+            "peak total_live was {}, so shares are invisible to the parent",
+            seen.load(Ordering::Relaxed)
+        );
+        // And it unwinds: nothing is left counted after the run.
+        assert_eq!(pool.total_live(), 0, "live count leaked after the run");
+    }
+
+    /// A `Collection` splits its pool across the readers running at once.
+    ///
+    /// The regression this guards: handing every reader the *same* pool lets
+    /// the first claim every slot, so the rest spawn nothing. Since only a
+    /// running worker spawns another, those readers never start and their input
+    /// is silently skipped -- the counts come back short, with no error.
+    #[test]
+    fn a_collection_processes_every_reader_from_a_shared_pool() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 5_000;
+        for readers in [1usize, 2, 4, 8] {
+            let mut proc = TallyProcessor::default();
+            let inner: Vec<_> = (0..readers)
+                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+                .collect();
+            let collection = Collection::new(inner, CollectionType::Single).unwrap();
+            // Fewer threads than readers, so the split rounds down toward zero
+            // and every share has to be floored at one.
+            collection
+                .process_parallel_pool(&mut proc, &ThreadPool::new(2), None)
+                .unwrap();
+            assert_eq!(
+                proc.total.load(Ordering::Relaxed),
+                N * readers,
+                "{readers} readers: some reader was never started"
+            );
+        }
+    }
+
+    /// The same, for the grouped (paired) dispatch path.
+    #[test]
+    fn a_paired_collection_processes_every_group() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 4_000;
+        #[derive(Clone, Default)]
+        struct PairTally {
+            total: Arc<AtomicUsize>,
+            local: usize,
+        }
+        impl<Rf: Record> crate::parallel::PairedParallelProcessor<Rf> for PairTally {
+            fn process_record_pair(&mut self, _r1: Rf, _r2: Rf) -> Result<(), ProcessError> {
+                self.local += 1;
+                Ok(())
+            }
+            fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
+                self.total.fetch_add(self.local, Ordering::Relaxed);
+                self.local = 0;
+                Ok(())
+            }
+        }
+
+        for pairs in [1usize, 2, 4] {
+            let mut proc = PairTally::default();
+            let inner: Vec<_> = (0..pairs * 2)
+                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+                .collect();
+            let collection = Collection::new(inner, CollectionType::Paired).unwrap();
+            collection
+                .process_parallel_paired_pool(&mut proc, &ThreadPool::new(2), None)
+                .unwrap();
+            assert_eq!(
+                proc.total.load(Ordering::Relaxed),
+                N * pairs,
+                "{pairs} pairs: some group was never started"
+            );
+        }
+    }
+
+    /// A share reads the same target as its parent, so one `set_threads`
+    /// retargets every reader at once.
+    #[test]
+    fn shares_track_the_parent_target() {
+        let pool = ThreadPool::with_max(16, 32);
+        let a = pool.share(4);
+        let b = pool.share(4);
+        assert_eq!(a.share_target(), 4);
+        assert_eq!(b.share_target(), 4);
+
+        pool.set_threads(32);
+        assert_eq!(a.share_target(), 8, "a share must see the parent resize");
+        assert_eq!(b.share_target(), 8);
+
+        // A share never rounds down to zero workers.
+        let thin = pool.share(64);
+        assert_eq!(thin.share_target(), 1);
+        assert_eq!(thin.share_max(), 1);
+
+        // Live counts are per share, not shared.
+        a.enter_live();
+        assert_eq!(a.live(), 1);
+        assert_eq!(b.live(), 0);
+        assert_eq!(pool.total_live(), 1, "the parent sees the aggregate");
+        a.exit_live();
+    }
+
+    /// A pool never exceeds the ceiling it was built with.
+    #[test]
+    fn the_maximum_is_respected() {
+        let pool = ThreadPool::with_max(2, 4);
+        pool.set_threads(999);
+        assert_eq!(pool.threads(), 4);
+        pool.set_threads(0);
+        assert_eq!(
+            pool.threads(),
+            1,
+            "a pool must always want at least one worker"
+        );
+    }
+}

--- a/src/parallel/reader.rs
+++ b/src/parallel/reader.rs
@@ -31,6 +31,16 @@ pub trait ParallelReader {
     where
         T: for<'a> ParallelProcessor<Self::Rf<'a>>;
 
+    /// As [`Self::process_parallel`], but the worker count may change while the
+    /// run is in flight. See [`crate::parallel::ThreadPool`].
+    fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+    ) -> Result<()>
+    where
+        T: for<'a> ParallelProcessor<Self::Rf<'a>>;
+
     fn process_parallel_paired<T>(
         self,
         r2: Self,
@@ -116,6 +126,23 @@ where
         T: for<'a> ParallelProcessor<S::RefRecord<'a>>,
     {
         process_parallel_generic(SingleReader::new(self), processor, num_threads)
+    }
+
+    fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+    ) -> Result<()>
+    where
+        T: for<'a> ParallelProcessor<S::RefRecord<'a>>,
+    {
+        crate::parallel::single::process_parallel_pool_range(
+            SingleReader::new(self),
+            processor,
+            pool,
+            0,
+            None,
+        )
     }
 
     fn process_parallel_range<T>(

--- a/src/parallel/reader.rs
+++ b/src/parallel/reader.rs
@@ -31,16 +31,6 @@ pub trait ParallelReader {
     where
         T: for<'a> ParallelProcessor<Self::Rf<'a>>;
 
-    /// As [`Self::process_parallel`], but the worker count may change while the
-    /// run is in flight. See [`crate::parallel::ThreadPool`].
-    fn process_parallel_pool<T>(
-        self,
-        processor: &mut T,
-        pool: &crate::parallel::ThreadPool,
-    ) -> Result<()>
-    where
-        T: for<'a> ParallelProcessor<Self::Rf<'a>>;
-
     fn process_parallel_paired<T>(
         self,
         r2: Self,
@@ -114,6 +104,24 @@ pub trait ParallelReader {
         T: for<'a> MultiParallelProcessor<Self::Rf<'a>>;
 }
 
+/// Opt-in parallel processing with a worker count that may change in flight.
+///
+/// This extension trait is available only with the `pool` feature. Keeping it
+/// separate from [`ParallelReader`] ensures enabling the pool adds a new path
+/// without changing the original fixed-thread interface or implementation.
+#[cfg(feature = "pool")]
+pub trait PoolParallelReader: ParallelReader {
+    /// As [`ParallelReader::process_parallel`], but the worker count may change
+    /// while the run is in flight. See [`crate::parallel::ThreadPool`].
+    fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+    ) -> Result<()>
+    where
+        T: for<'a> ParallelProcessor<Self::Rf<'a>>;
+}
+
 impl<S: GenericReader> ParallelReader for S
 where
     for<'a> <S as GenericReader>::RefRecord<'a>: Record,
@@ -126,23 +134,6 @@ where
         T: for<'a> ParallelProcessor<S::RefRecord<'a>>,
     {
         process_parallel_generic(SingleReader::new(self), processor, num_threads)
-    }
-
-    fn process_parallel_pool<T>(
-        self,
-        processor: &mut T,
-        pool: &crate::parallel::ThreadPool,
-    ) -> Result<()>
-    where
-        T: for<'a> ParallelProcessor<S::RefRecord<'a>>,
-    {
-        crate::parallel::single::process_parallel_pool_range(
-            SingleReader::new(self),
-            processor,
-            pool,
-            0,
-            None,
-        )
     }
 
     fn process_parallel_range<T>(
@@ -285,6 +276,30 @@ where
             num_threads,
             start,
             limit,
+        )
+    }
+}
+
+#[cfg(feature = "pool")]
+impl<S: GenericReader> PoolParallelReader for S
+where
+    for<'a> <S as GenericReader>::RefRecord<'a>: Record,
+    ProcessError: From<S::Error>,
+{
+    fn process_parallel_pool<T>(
+        self,
+        processor: &mut T,
+        pool: &crate::parallel::ThreadPool,
+    ) -> Result<()>
+    where
+        T: for<'a> ParallelProcessor<S::RefRecord<'a>>,
+    {
+        crate::parallel::pool::process_parallel_pool_range(
+            SingleReader::new(self),
+            processor,
+            pool,
+            0,
+            None,
         )
     }
 }

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -158,59 +158,36 @@ where
     let order_gate = Arc::new(OrderGate::new());
     let ordered = processor.requires_ordering();
 
-    // Workers spawned after the initial wave are in no handle list, so their
-    // errors are collected here rather than by `join`. `thread::scope` still
-    // joins every worker before its closure returns, so reading this afterwards
-    // cannot race.
     let first_error: Mutex<Option<ProcessError>> = Mutex::new(None);
-    let next_id = AtomicUsize::new(0);
-    // Set as soon as any worker sees the input end.
-    //
-    // Without it, a worker leaving at EOF drops `live` below `target`, every
-    // remaining worker reads that as "the pool is short", and each spawns a
-    // replacement that immediately hits EOF and does the same. Measured before
-    // this existed: 3.1 million workers spawned for a 32-thread run.
+    // Set at end of input (or when the record limit is reached). Parked
+    // workers wait on the pool's gate with this in their predicate, so setting
+    // it must be paired with `pool.wake_all()` or they would sleep forever.
     let finished = AtomicBool::new(false);
-    // New workers are cloned from this, never from a running worker.
-    //
-    // `Clone` on a processor means "give me a fresh worker" -- the fixed path
-    // only ever clones the caller's untouched instance. Cloning a worker
-    // mid-flight instead copies whatever it has accumulated, and any processor
-    // keeping per-thread tallies then double-counts them when both flush in
-    // `on_thread_complete`. That turned an 8 million record file into 791
-    // billion records.
-    let template: Mutex<T> = Mutex::new(processor.clone());
 
     thread::scope(|scope| -> Result<()> {
         let reader = &reader;
         let ctx = WorkerCtx {
             reader,
             pool,
-            next_id: &next_id,
             first_error: &first_error,
             finished: &finished,
-            template: &template,
             order_gate: &order_gate,
             ordered,
             offset,
             limit,
         };
 
-        // At least one worker always starts: `share_target` floors at one and a
-        // share's live count starts at zero, so the first claim cannot fail.
-        // That matters more than it looks -- a share that spawned no workers
-        // would return immediately and silently skip its whole input, and no
-        // later growth could rescue it, because only a running worker spawns
-        // another.
-        for _ in 0..num_threads {
-            if !pool.try_claim_slot() {
-                break;
-            }
+        // The whole spawn set, once, each worker with a stable index. A worker
+        // whose index is at or above the target parks immediately (allocating
+        // nothing); growth wakes it. Because nothing ever spawns after this
+        // loop, the worker count is bounded by construction -- there is no
+        // claim/release accounting to race against EOF.
+        for worker_id in 0..pool.share_max() {
             spawn_worker(
                 scope,
                 &ctx,
+                worker_id,
                 processor.clone(),
-                reader.new_record_set(),
                 records_processed.clone(),
             );
         }
@@ -227,65 +204,98 @@ where
 ///
 /// Grouped so that spawning one takes three arguments rather than a dozen, and
 /// so a worker can hand the same context to a successor.
-struct WorkerCtx<'env, S, T> {
+struct WorkerCtx<'env, S> {
     reader: &'env S,
     pool: &'env crate::parallel::ThreadPool,
-    next_id: &'env AtomicUsize,
     first_error: &'env Mutex<Option<ProcessError>>,
     finished: &'env AtomicBool,
-    template: &'env Mutex<T>,
     order_gate: &'env Arc<OrderGate>,
     ordered: bool,
     offset: usize,
     limit: Option<usize>,
 }
 
-impl<S, T> Clone for WorkerCtx<'_, S, T> {
+impl<S> Clone for WorkerCtx<'_, S> {
     fn clone(&self) -> Self {
         *self
     }
 }
-impl<S, T> Copy for WorkerCtx<'_, S, T> {}
+impl<S> Copy for WorkerCtx<'_, S> {}
 
-/// Run one worker, and let it spawn successors when the pool grows.
+/// Run one worker of the fixed spawn set.
 ///
-/// Spawning from inside a worker rather than from a dedicated coordinator puts
-/// the cost where it is already amortised: a worker checks the pool once per
-/// *batch*, between finishing one and asking for the next. No coordinator
-/// thread, and no polling interval to tune.
+/// The worker parks when its index is at or above the target and resumes when
+/// growth brings the target back over it. It allocates its `RecordSet` lazily,
+/// on first activation, so a worker that never runs holds no batch memory.
+/// Parking happens only at a batch boundary, after the order gate has been
+/// advanced past the batch in hand, so ordered mode never waits on a turn a
+/// parked worker owes.
 fn spawn_worker<'scope, 'env, S, T>(
     scope: &'scope thread::Scope<'scope, 'env>,
-    ctx: &WorkerCtx<'env, S, T>,
+    ctx: &WorkerCtx<'env, S>,
+    worker_id: usize,
     mut worker_processor: T,
-    mut record_set: S::RecordSet,
     records_processed: Arc<AtomicUsize>,
 ) where
     S: MTGenericReader + Sync + 'env,
     T: for<'a> GenericProcessor<S::RefRecord<'a>> + Send + 'env,
 {
     let ctx = *ctx;
-    let thread_id = ctx.next_id.fetch_add(1, Ordering::Relaxed);
     scope.spawn(move || {
-        let mut retired = false;
+        let mut record_set: Option<S::RecordSet> = None;
+        let mut active = false;
 
         // As in the fixed path: run the body in a closure so any error can
         // poison the order gate before propagating, rather than deadlocking
         // workers waiting on a batch that will never complete.
         let result: Result<()> = (|| {
-            worker_processor.set_thread_id(thread_id);
+            worker_processor.set_thread_id(worker_id);
 
             loop {
+                if ctx.finished.load(Ordering::Acquire) {
+                    break;
+                }
+                // Over target: park until growth or end of input. The
+                // predicate is re-checked under the pool's gate, and both
+                // `set_threads` and the finished path notify under that same
+                // gate, so the wakeup cannot be lost.
+                if worker_id >= ctx.pool.share_target() {
+                    if active {
+                        ctx.pool.exit_live();
+                        active = false;
+                    }
+                    // Parked memory is proportional to *active* workers: the
+                    // batch in this set was fully processed and the order gate
+                    // advanced past it before we got here, so its contents are
+                    // dead -- drop the buffers rather than hold megabytes idle
+                    // for however long the pool stays shrunk. Re-activation
+                    // re-allocates; resizes happen on controller cadences
+                    // (hundreds of ms), so the churn is noise.
+                    record_set = None;
+                    ctx.pool.park_until(|| {
+                        worker_id < ctx.pool.share_target() || ctx.finished.load(Ordering::Acquire)
+                    });
+                    continue;
+                }
+                if !active {
+                    ctx.pool.enter_live();
+                    active = true;
+                }
+                let record_set = record_set.get_or_insert_with(|| ctx.reader.new_record_set());
+
                 if let Some(lim) = ctx.limit {
                     if records_processed.load(Ordering::Relaxed) >= lim {
-                        ctx.finished.store(true, Ordering::Relaxed);
+                        ctx.finished.store(true, Ordering::Release);
+                        ctx.pool.wake_all();
                         break;
                     }
                 }
 
                 let Some((batch_start, batch_end)) =
-                    ctx.reader.fill(&mut record_set).map_err(Into::into)?
+                    ctx.reader.fill(record_set).map_err(Into::into)?
                 else {
-                    ctx.finished.store(true, Ordering::Relaxed);
+                    ctx.finished.store(true, Ordering::Release);
+                    ctx.pool.wake_all();
                     break; // EOF
                 };
                 let batch_size = batch_end - batch_start;
@@ -298,7 +308,8 @@ fn spawn_worker<'scope, 'env, S, T>(
                     continue;
                 }
                 if batch_start >= range_end {
-                    ctx.finished.store(true, Ordering::Relaxed);
+                    ctx.finished.store(true, Ordering::Release);
+                    ctx.pool.wake_all();
                     break;
                 }
 
@@ -306,7 +317,7 @@ fn spawn_worker<'scope, 'env, S, T>(
                 let take_count =
                     (batch_size - skip_in_batch).min(range_end - batch_start - skip_in_batch);
 
-                let records = S::iter(&record_set)
+                let records = S::iter(record_set)
                     .skip(skip_in_batch)
                     .take(take_count)
                     .map(|r| r.map_err(Into::into));
@@ -323,42 +334,23 @@ fn spawn_worker<'scope, 'env, S, T>(
                 if ctx.ordered {
                     ctx.order_gate.advance(batch_end);
                 }
-
-                // Resize *here*, after the order gate has been advanced past
-                // this batch. Retiring while the gate still expects this worker
-                // to advance it would stall every other worker behind a turn
-                // that never comes.
-                //
-                // The whole steady-state cost of a resizable pool: two relaxed
-                // loads, taking neither branch unless the target has moved.
-                if ctx.pool.try_release_slot() {
-                    retired = true;
-                    break;
-                }
-                while !ctx.finished.load(Ordering::Relaxed) && ctx.pool.try_claim_slot() {
-                    let fresh = ctx.template.lock().unwrap().clone();
-                    // Allocated on this thread rather than the new worker's, so
-                    // the allocation pattern matches the fixed path exactly.
-                    // Still only when a worker is really created, so nothing is
-                    // pre-allocated for a worker that never exists.
-                    let fresh_set = ctx.reader.new_record_set();
-                    spawn_worker(scope, &ctx, fresh, fresh_set, records_processed.clone());
-                }
             }
-            // Retiring workers flush too: `on_thread_complete` is where a
-            // processor commits its per-thread state, and a worker that leaves
-            // mid-run has just as much to commit as one that reaches EOF.
             worker_processor.on_thread_complete()?;
             Ok(())
         })();
 
-        if !retired {
-            ctx.pool.release_slot();
+        if active {
+            ctx.pool.exit_live();
         }
         if let Err(e) = result {
             if ctx.ordered {
                 ctx.order_gate.poison();
             }
+            // An erroring worker also ends the run for its peers -- parked
+            // workers in particular, who would otherwise sleep until a wakeup
+            // that is never coming once their siblings have stopped filling.
+            ctx.finished.store(true, Ordering::Release);
+            ctx.pool.wake_all();
             let mut slot = ctx.first_error.lock().unwrap();
             if slot.is_none() {
                 *slot = Some(e);
@@ -984,28 +976,53 @@ mod pool_tests {
         }
     }
 
-    /// Regression: a worker leaving at EOF drops `live` below `target`, and
-    /// every remaining worker used to read that as "the pool is short" and
-    /// spawn a replacement, which hit EOF and did the same. That produced 3.1
-    /// million workers for a 32-thread run over an 8 M record file.
+    /// Regression: a worker leaving at EOF used to drop `live` below
+    /// `target`, every remaining worker read that as "the pool is short" and
+    /// spawned a replacement, which hit EOF and did the same — 3.1 million
+    /// workers for a 32-thread run over an 8 M record file. Even with an EOF
+    /// guard, a small input could race 9 concurrent workers into an 8-worker
+    /// pool, because peers made spawn decisions from observed live counts.
     ///
-    /// The record count catches it; `threads_completed` catches it loudly.
+    /// The fixed spawn set makes the bound structural: workers are spawned
+    /// once with stable indices and nothing spawns afterwards, so there is no
+    /// decision left to race on. The input here is deliberately tiny (the size
+    /// at which the old design failed deterministically), the run is repeated,
+    /// and *concurrency* is measured directly rather than inferred from
+    /// completion counts.
     #[test]
-    fn workers_leaving_at_eof_do_not_spawn_replacements() {
-        const N: usize = 20_000;
-        let mut proc = TallyProcessor::default();
-        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
-        reader
-            .process_parallel_pool(&mut proc, &ThreadPool::new(8))
-            .unwrap();
+    fn worker_concurrency_is_bounded_by_construction() {
+        const N: usize = 200;
+        #[derive(Clone, Default)]
+        struct ConcurrencyProbe {
+            current: Arc<AtomicUsize>,
+            peak: Arc<AtomicUsize>,
+            total: Arc<AtomicUsize>,
+        }
+        impl<Rf: crate::Record> crate::parallel::ParallelProcessor<Rf> for ConcurrencyProbe {
+            fn process_record(&mut self, _r: Rf) -> Result<(), ProcessError> {
+                let now = self.current.fetch_add(1, Ordering::AcqRel) + 1;
+                self.peak.fetch_max(now, Ordering::AcqRel);
+                self.total.fetch_add(1, Ordering::Relaxed);
+                self.current.fetch_sub(1, Ordering::AcqRel);
+                Ok(())
+            }
+        }
 
-        assert_eq!(proc.total.load(Ordering::Relaxed), N);
-        assert!(
-            proc.threads_completed.load(Ordering::Relaxed) <= 8,
-            "{} workers ran for an 8-worker pool: EOF is being mistaken for a \
-             shortfall and workers are respawning each other",
-            proc.threads_completed.load(Ordering::Relaxed)
-        );
+        for _ in 0..25 {
+            let proc_template = ConcurrencyProbe::default();
+            let mut proc = proc_template.clone();
+            let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+            reader
+                .process_parallel_pool(&mut proc, &ThreadPool::new(8))
+                .unwrap();
+            assert_eq!(proc_template.total.load(Ordering::Relaxed), N);
+            let peak = proc_template.peak.load(Ordering::Relaxed);
+            assert!(
+                peak <= 8,
+                "{peak} concurrent workers in an 8-worker pool: the spawn-set \
+                 bound has been broken"
+            );
+        }
     }
 
     /// Regression: new workers must be cloned from the caller's pristine
@@ -1259,11 +1276,12 @@ mod pool_tests {
         assert_eq!(thin.share_target(), 1);
         assert_eq!(thin.share_max(), 1);
 
-        // Live counts are per share, not shared: claiming in one leaves the
-        // other untouched.
-        assert!(a.try_claim_slot());
+        // Live counts are per share, not shared.
+        a.enter_live();
         assert_eq!(a.live(), 1);
         assert_eq!(b.live(), 0);
+        assert_eq!(pool.total_live(), 1, "the parent sees the aggregate");
+        a.exit_live();
     }
 
     /// A pool never exceeds the ceiling it was built with.

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -1124,6 +1124,52 @@ mod pool_tests {
         assert_eq!(proc.total.load(Ordering::Relaxed), N);
     }
 
+    /// A supervisor outside the run needs the aggregate live count.
+    ///
+    /// `live()` reports one share, and the pool a caller holds is the *parent*,
+    /// whose own share never runs anything once a `Collection` splits it — so the
+    /// obvious reading is zero for the whole run. An external scheduler normalising
+    /// work against "threads running" then divides by nothing and concludes the
+    /// consumer is never busy.
+    #[test]
+    fn total_live_counts_workers_across_every_share() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(8, 8);
+        let observer = pool.clone();
+        let seen = Arc::new(AtomicUsize::new(0));
+        let s2 = Arc::clone(&seen);
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let st2 = Arc::clone(&stop);
+        let watcher = std::thread::spawn(move || {
+            while !st2.load(Ordering::Relaxed) {
+                s2.fetch_max(observer.total_live(), Ordering::Relaxed);
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+        });
+
+        let mut proc = TallyProcessor::default();
+        let inner: Vec<_> = (0..4)
+            .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+            .collect();
+        Collection::new(inner, CollectionType::Single)
+            .unwrap()
+            .process_parallel_pool(&mut proc, &pool, None)
+            .unwrap();
+        stop.store(true, Ordering::Relaxed);
+        watcher.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N * 4);
+        assert!(
+            seen.load(Ordering::Relaxed) > 1,
+            "peak total_live was {}, so shares are invisible to the parent",
+            seen.load(Ordering::Relaxed)
+        );
+        // And it unwinds: nothing is left counted after the run.
+        assert_eq!(pool.total_live(), 0, "live count leaked after the run");
+    }
+
     /// A `Collection` splits its pool across the readers running at once.
     ///
     /// The regression this guards: handing every reader the *same* pool lets

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -141,14 +141,14 @@ pub(crate) fn process_parallel_pool_range<S: MTGenericReader, T>(
 where
     T: for<'a> GenericProcessor<S::RefRecord<'a>>,
 {
-    let mut num_threads = pool.threads();
+    let mut num_threads = pool.share_target();
     if num_threads == 0 {
         num_threads = num_cpus::get();
     }
     // Only when the pool can never grow. A pool that *starts* at one worker but
     // may be resized has to take the parallel path anyway, or it could never
     // honour a later `set_threads` -- there is no pool in the sequential path.
-    if num_threads == 1 && pool.max_threads() == 1 {
+    if num_threads == 1 && pool.share_max() == 1 {
         return process_sequential_generic_range(reader, processor, offset, limit);
     }
 
@@ -196,6 +196,12 @@ where
             limit,
         };
 
+        // At least one worker always starts: `share_target` floors at one and a
+        // share's live count starts at zero, so the first claim cannot fail.
+        // That matters more than it looks -- a share that spawned no workers
+        // would return immediately and silently skip its whole input, and no
+        // later growth could rescue it, because only a running worker spawns
+        // another.
         for _ in 0..num_threads {
             if !pool.try_claim_slot() {
                 break;
@@ -1116,6 +1122,102 @@ mod pool_tests {
         churner.join().unwrap();
 
         assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// A `Collection` splits its pool across the readers running at once.
+    ///
+    /// The regression this guards: handing every reader the *same* pool lets
+    /// the first claim every slot, so the rest spawn nothing. Since only a
+    /// running worker spawns another, those readers never start and their input
+    /// is silently skipped -- the counts come back short, with no error.
+    #[test]
+    fn a_collection_processes_every_reader_from_a_shared_pool() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 5_000;
+        for readers in [1usize, 2, 4, 8] {
+            let mut proc = TallyProcessor::default();
+            let inner: Vec<_> = (0..readers)
+                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+                .collect();
+            let collection = Collection::new(inner, CollectionType::Single).unwrap();
+            // Fewer threads than readers, so the split rounds down toward zero
+            // and every share has to be floored at one.
+            collection
+                .process_parallel_pool(&mut proc, &ThreadPool::new(2), None)
+                .unwrap();
+            assert_eq!(
+                proc.total.load(Ordering::Relaxed),
+                N * readers,
+                "{readers} readers: some reader was never started"
+            );
+        }
+    }
+
+    /// The same, for the grouped (paired) dispatch path.
+    #[test]
+    fn a_paired_collection_processes_every_group() {
+        use crate::fastx::{Collection, CollectionType};
+
+        const N: usize = 4_000;
+        #[derive(Clone, Default)]
+        struct PairTally {
+            total: Arc<AtomicUsize>,
+            local: usize,
+        }
+        impl<Rf: Record> crate::parallel::PairedParallelProcessor<Rf> for PairTally {
+            fn process_record_pair(&mut self, _r1: Rf, _r2: Rf) -> Result<(), ProcessError> {
+                self.local += 1;
+                Ok(())
+            }
+            fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
+                self.total.fetch_add(self.local, Ordering::Relaxed);
+                self.local = 0;
+                Ok(())
+            }
+        }
+
+        for pairs in [1usize, 2, 4] {
+            let mut proc = PairTally::default();
+            let inner: Vec<_> = (0..pairs * 2)
+                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
+                .collect();
+            let collection = Collection::new(inner, CollectionType::Paired).unwrap();
+            collection
+                .process_parallel_paired_pool(&mut proc, &ThreadPool::new(2), None)
+                .unwrap();
+            assert_eq!(
+                proc.total.load(Ordering::Relaxed),
+                N * pairs,
+                "{pairs} pairs: some group was never started"
+            );
+        }
+    }
+
+    /// A share reads the same target as its parent, so one `set_threads`
+    /// retargets every reader at once.
+    #[test]
+    fn shares_track_the_parent_target() {
+        let pool = ThreadPool::with_max(16, 32);
+        let a = pool.share(4);
+        let b = pool.share(4);
+        assert_eq!(a.share_target(), 4);
+        assert_eq!(b.share_target(), 4);
+
+        pool.set_threads(32);
+        assert_eq!(a.share_target(), 8, "a share must see the parent resize");
+        assert_eq!(b.share_target(), 8);
+
+        // A share never rounds down to zero workers.
+        let thin = pool.share(64);
+        assert_eq!(thin.share_target(), 1);
+        assert_eq!(thin.share_max(), 1);
+
+        // Live counts are per share, not shared: claiming in one leaves the
+        // other untouched.
+        assert!(a.try_claim_slot());
+        assert_eq!(a.live(), 1);
+        assert_eq!(b.live(), 0);
     }
 
     /// A pool never exceeds the ceiling it was built with.

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -3,8 +3,8 @@ use itertools::Itertools;
 use crate::parallel::ordered::OrderGate;
 use crate::parallel::processor::GenericProcessor;
 use crate::parallel::{error::Result, ProcessError};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 /// A Sync version of GenericReader, i.e. for types with internal mutexes that can be shared between threads.
@@ -108,19 +108,47 @@ where
 }
 
 pub(crate) fn process_parallel_generic_range<S: MTGenericReader, T>(
-    mut reader: S,
+    reader: S,
     processor: &mut T,
-    mut num_threads: usize,
+    num_threads: usize,
     offset: usize,
     limit: Option<usize>,
 ) -> Result<()>
 where
     T: for<'a> GenericProcessor<S::RefRecord<'a>>,
 {
+    // A pool whose target never moves is exactly a fixed worker count. There is
+    // one implementation rather than two, so the resizable path cannot drift
+    // from the fixed one.
+    process_parallel_pool_range(
+        reader,
+        processor,
+        &crate::parallel::ThreadPool::new(num_threads),
+        offset,
+        limit,
+    )
+}
+
+/// As [`process_parallel_generic_range`], but the worker count may change while
+/// the run is in flight. See [`crate::parallel::ThreadPool`].
+pub(crate) fn process_parallel_pool_range<S: MTGenericReader, T>(
+    mut reader: S,
+    processor: &mut T,
+    pool: &crate::parallel::ThreadPool,
+    offset: usize,
+    limit: Option<usize>,
+) -> Result<()>
+where
+    T: for<'a> GenericProcessor<S::RefRecord<'a>>,
+{
+    let mut num_threads = pool.threads();
     if num_threads == 0 {
         num_threads = num_cpus::get();
     }
-    if num_threads == 1 {
+    // Only when the pool can never grow. A pool that *starts* at one worker but
+    // may be resized has to take the parallel path anyway, or it could never
+    // honour a later `set_threads` -- there is no pool in the sequential path.
+    if num_threads == 1 && pool.max_threads() == 1 {
         return process_sequential_generic_range(reader, processor, offset, limit);
     }
 
@@ -130,113 +158,207 @@ where
     let order_gate = Arc::new(OrderGate::new());
     let ordered = processor.requires_ordering();
 
+    // Workers spawned after the initial wave are in no handle list, so their
+    // errors are collected here rather than by `join`. `thread::scope` still
+    // joins every worker before its closure returns, so reading this afterwards
+    // cannot race.
+    let first_error: Mutex<Option<ProcessError>> = Mutex::new(None);
+    let next_id = AtomicUsize::new(0);
+    // Set as soon as any worker sees the input end.
+    //
+    // Without it, a worker leaving at EOF drops `live` below `target`, every
+    // remaining worker reads that as "the pool is short", and each spawns a
+    // replacement that immediately hits EOF and does the same. Measured before
+    // this existed: 3.1 million workers spawned for a 32-thread run.
+    let finished = AtomicBool::new(false);
+    // New workers are cloned from this, never from a running worker.
+    //
+    // `Clone` on a processor means "give me a fresh worker" -- the fixed path
+    // only ever clones the caller's untouched instance. Cloning a worker
+    // mid-flight instead copies whatever it has accumulated, and any processor
+    // keeping per-thread tallies then double-counts them when both flush in
+    // `on_thread_complete`. That turned an 8 million record file into 791
+    // billion records.
+    let template: Mutex<T> = Mutex::new(processor.clone());
+
     thread::scope(|scope| -> Result<()> {
         let reader = &reader;
+        let ctx = WorkerCtx {
+            reader,
+            pool,
+            next_id: &next_id,
+            first_error: &first_error,
+            finished: &finished,
+            template: &template,
+            order_gate: &order_gate,
+            ordered,
+            offset,
+            limit,
+        };
 
-        let mut handles = Vec::new();
-        for thread_id in 0..num_threads {
-            let mut worker_processor = processor.clone();
-            let mut record_set = reader.new_record_set();
-            let records_processed = records_processed.clone();
-            let order_gate = order_gate.clone();
-
-            let handle = scope.spawn(move || {
-                // Run the worker body in a closure so any error path below can
-                // poison the order gate before propagating - otherwise other
-                // threads waiting on a batch that will never complete would
-                // deadlock instead of unwinding.
-                let result: Result<()> = (|| {
-                    worker_processor.set_thread_id(thread_id);
-
-                    loop {
-                        // Check limit before grabbing batch
-                        if let Some(lim) = limit {
-                            if records_processed.load(Ordering::Relaxed) >= lim {
-                                break;
-                            }
-                        }
-
-                        // Fill the batch; `fill` itself claims this batch's
-                        // stream position atomically (see the trait docs).
-                        let Some((batch_start, batch_end)) =
-                            reader.fill(&mut record_set).map_err(Into::into)?
-                        else {
-                            break; // EOF
-                        };
-                        let batch_size = batch_end - batch_start;
-
-                        // Determine overlap with target range [offset, offset+limit)
-                        let range_end = limit.map(|lim| offset + lim).unwrap_or(usize::MAX);
-
-                        if batch_end <= offset {
-                            // Entire batch before offset - skip it. Still catch
-                            // the order gate up to this point so the first
-                            // processed batch's wait_turn isn't stuck waiting
-                            // for skipped ground it will never claim.
-                            if ordered {
-                                order_gate.advance(batch_end);
-                            }
-                            continue;
-                        }
-
-                        if batch_start >= range_end {
-                            // Entire batch after limit - done
-                            break;
-                        }
-
-                        // Calculate slice of this batch within range
-                        let skip_in_batch = offset.saturating_sub(batch_start);
-                        let take_count = (batch_size - skip_in_batch)
-                            .min(range_end - batch_start - skip_in_batch);
-
-                        // Process the slice
-                        let records = S::iter(&record_set)
-                            .skip(skip_in_batch)
-                            .take(take_count)
-                            .map(|r| r.map_err(Into::into));
-
-                        records.process_results(|records| {
-                            worker_processor.process_record_batch(records)
-                        })??;
-
-                        records_processed.fetch_add(take_count, Ordering::Relaxed);
-
-                        // Only the commit step is serialized to stream order;
-                        // process_record_batch above already ran unordered.
-                        if ordered {
-                            order_gate.wait_turn(batch_start);
-                        }
-                        worker_processor.on_batch_complete()?;
-                        if ordered {
-                            order_gate.advance(batch_end);
-                        }
-                    }
-                    worker_processor.on_thread_complete()?;
-                    Ok(())
-                })();
-
-                if result.is_err() && ordered {
-                    order_gate.poison();
-                }
-                result
-            });
-
-            handles.push(handle);
-        }
-
-        // Wait for workers
-        for handle in handles {
-            match handle.join() {
-                Ok(Ok(())) => (),
-                Ok(Err(e)) => return Err(e),
-                Err(_) => return Err(ProcessError::JoinError),
+        for _ in 0..num_threads {
+            if !pool.try_claim_slot() {
+                break;
             }
+            spawn_worker(
+                scope,
+                &ctx,
+                processor.clone(),
+                reader.new_record_set(),
+                records_processed.clone(),
+            );
         }
-
         Ok(())
     })?;
 
-    Ok(())
+    match first_error.into_inner().unwrap_or(None) {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Everything a worker needs that is identical for every worker.
+///
+/// Grouped so that spawning one takes three arguments rather than a dozen, and
+/// so a worker can hand the same context to a successor.
+struct WorkerCtx<'env, S, T> {
+    reader: &'env S,
+    pool: &'env crate::parallel::ThreadPool,
+    next_id: &'env AtomicUsize,
+    first_error: &'env Mutex<Option<ProcessError>>,
+    finished: &'env AtomicBool,
+    template: &'env Mutex<T>,
+    order_gate: &'env Arc<OrderGate>,
+    ordered: bool,
+    offset: usize,
+    limit: Option<usize>,
+}
+
+impl<S, T> Clone for WorkerCtx<'_, S, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<S, T> Copy for WorkerCtx<'_, S, T> {}
+
+/// Run one worker, and let it spawn successors when the pool grows.
+///
+/// Spawning from inside a worker rather than from a dedicated coordinator puts
+/// the cost where it is already amortised: a worker checks the pool once per
+/// *batch*, between finishing one and asking for the next. No coordinator
+/// thread, and no polling interval to tune.
+fn spawn_worker<'scope, 'env, S, T>(
+    scope: &'scope thread::Scope<'scope, 'env>,
+    ctx: &WorkerCtx<'env, S, T>,
+    mut worker_processor: T,
+    mut record_set: S::RecordSet,
+    records_processed: Arc<AtomicUsize>,
+) where
+    S: MTGenericReader + Sync + 'env,
+    T: for<'a> GenericProcessor<S::RefRecord<'a>> + Send + 'env,
+{
+    let ctx = *ctx;
+    let thread_id = ctx.next_id.fetch_add(1, Ordering::Relaxed);
+    scope.spawn(move || {
+        let mut retired = false;
+
+        // As in the fixed path: run the body in a closure so any error can
+        // poison the order gate before propagating, rather than deadlocking
+        // workers waiting on a batch that will never complete.
+        let result: Result<()> = (|| {
+            worker_processor.set_thread_id(thread_id);
+
+            loop {
+                if let Some(lim) = ctx.limit {
+                    if records_processed.load(Ordering::Relaxed) >= lim {
+                        ctx.finished.store(true, Ordering::Relaxed);
+                        break;
+                    }
+                }
+
+                let Some((batch_start, batch_end)) =
+                    ctx.reader.fill(&mut record_set).map_err(Into::into)?
+                else {
+                    ctx.finished.store(true, Ordering::Relaxed);
+                    break; // EOF
+                };
+                let batch_size = batch_end - batch_start;
+                let range_end = ctx.limit.map(|lim| ctx.offset + lim).unwrap_or(usize::MAX);
+
+                if batch_end <= ctx.offset {
+                    if ctx.ordered {
+                        ctx.order_gate.advance(batch_end);
+                    }
+                    continue;
+                }
+                if batch_start >= range_end {
+                    ctx.finished.store(true, Ordering::Relaxed);
+                    break;
+                }
+
+                let skip_in_batch = ctx.offset.saturating_sub(batch_start);
+                let take_count =
+                    (batch_size - skip_in_batch).min(range_end - batch_start - skip_in_batch);
+
+                let records = S::iter(&record_set)
+                    .skip(skip_in_batch)
+                    .take(take_count)
+                    .map(|r| r.map_err(Into::into));
+
+                records
+                    .process_results(|records| worker_processor.process_record_batch(records))??;
+
+                records_processed.fetch_add(take_count, Ordering::Relaxed);
+
+                if ctx.ordered {
+                    ctx.order_gate.wait_turn(batch_start);
+                }
+                worker_processor.on_batch_complete()?;
+                if ctx.ordered {
+                    ctx.order_gate.advance(batch_end);
+                }
+
+                // Resize *here*, after the order gate has been advanced past
+                // this batch. Retiring while the gate still expects this worker
+                // to advance it would stall every other worker behind a turn
+                // that never comes.
+                //
+                // The whole steady-state cost of a resizable pool: two relaxed
+                // loads, taking neither branch unless the target has moved.
+                if ctx.pool.try_release_slot() {
+                    retired = true;
+                    break;
+                }
+                while !ctx.finished.load(Ordering::Relaxed) && ctx.pool.try_claim_slot() {
+                    let fresh = ctx.template.lock().unwrap().clone();
+                    // Allocated on this thread rather than the new worker's, so
+                    // the allocation pattern matches the fixed path exactly.
+                    // Still only when a worker is really created, so nothing is
+                    // pre-allocated for a worker that never exists.
+                    let fresh_set = ctx.reader.new_record_set();
+                    spawn_worker(scope, &ctx, fresh, fresh_set, records_processed.clone());
+                }
+            }
+            // Retiring workers flush too: `on_thread_complete` is where a
+            // processor commits its per-thread state, and a worker that leaves
+            // mid-run has just as much to commit as one that reaches EOF.
+            worker_processor.on_thread_complete()?;
+            Ok(())
+        })();
+
+        if !retired {
+            ctx.pool.release_slot();
+        }
+        if let Err(e) = result {
+            if ctx.ordered {
+                ctx.order_gate.poison();
+            }
+            let mut slot = ctx.first_error.lock().unwrap();
+            if slot.is_none() {
+                *slot = Some(e);
+            }
+        }
+    });
 }
 
 #[cfg(test)]
@@ -799,6 +921,214 @@ mod tests {
             p5.count(),
             50,
             "multi-interleaved should process 50 record-groups"
+        );
+    }
+}
+
+#[cfg(test)]
+mod pool_tests {
+    use std::io::Cursor;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use crate::fastq;
+    use crate::parallel::{ParallelProcessor, ParallelReader, ProcessError, ThreadPool};
+    use crate::Record;
+
+    fn make_fastq(n: usize) -> Vec<u8> {
+        (0..n)
+            .flat_map(|i| format!("@seq{i}\nACGT\n+\nIIII\n").into_bytes())
+            .collect()
+    }
+
+    /// Deliberately keeps per-thread state and only publishes it in
+    /// `on_thread_complete`, exactly as a real processor does. That is what
+    /// makes it sensitive to *where* a new worker's clone comes from.
+    #[derive(Clone, Default)]
+    struct TallyProcessor {
+        total: Arc<AtomicUsize>,
+        threads_completed: Arc<AtomicUsize>,
+        local: usize,
+    }
+
+    impl<Rf: Record> ParallelProcessor<Rf> for TallyProcessor {
+        fn process_record(&mut self, _record: Rf) -> Result<(), ProcessError> {
+            self.local += 1;
+            Ok(())
+        }
+        fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
+            self.total.fetch_add(self.local, Ordering::Relaxed);
+            self.threads_completed.fetch_add(1, Ordering::Relaxed);
+            self.local = 0;
+            Ok(())
+        }
+    }
+
+    /// A pool that never resizes must behave exactly like a fixed count.
+    #[test]
+    fn a_fixed_pool_matches_a_fixed_thread_count() {
+        const N: usize = 5_000;
+        for threads in [1usize, 2, 8] {
+            let mut proc = TallyProcessor::default();
+            let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+            reader
+                .process_parallel_pool(&mut proc, &ThreadPool::new(threads))
+                .unwrap();
+            assert_eq!(proc.total.load(Ordering::Relaxed), N, "threads {threads}");
+        }
+    }
+
+    /// Regression: a worker leaving at EOF drops `live` below `target`, and
+    /// every remaining worker used to read that as "the pool is short" and
+    /// spawn a replacement, which hit EOF and did the same. That produced 3.1
+    /// million workers for a 32-thread run over an 8 M record file.
+    ///
+    /// The record count catches it; `threads_completed` catches it loudly.
+    #[test]
+    fn workers_leaving_at_eof_do_not_spawn_replacements() {
+        const N: usize = 20_000;
+        let mut proc = TallyProcessor::default();
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader
+            .process_parallel_pool(&mut proc, &ThreadPool::new(8))
+            .unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+        assert!(
+            proc.threads_completed.load(Ordering::Relaxed) <= 8,
+            "{} workers ran for an 8-worker pool: EOF is being mistaken for a \
+             shortfall and workers are respawning each other",
+            proc.threads_completed.load(Ordering::Relaxed)
+        );
+    }
+
+    /// Regression: new workers must be cloned from the caller's pristine
+    /// processor, never from a running one.
+    ///
+    /// `Clone` on a processor means "give me a fresh worker". Cloning a worker
+    /// mid-flight copies its accumulated `local`, and both copies then publish
+    /// it in `on_thread_complete` -- turning 8 M records into 791 billion.
+    #[test]
+    fn grown_workers_start_from_a_pristine_processor() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(1, 8);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let grower = std::thread::spawn(move || {
+            for n in 2..=8 {
+                std::thread::sleep(std::time::Duration::from_micros(200));
+                p2.set_threads(n);
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        grower.join().unwrap();
+
+        assert_eq!(
+            proc.total.load(Ordering::Relaxed),
+            N,
+            "records were counted more than once: a growing worker inherited \
+             another worker's partial tally"
+        );
+    }
+
+    /// Growth has to be reachable from a single worker, which means the
+    /// `num_threads == 1` sequential short-circuit must look at whether the
+    /// pool *can* grow, not at where it starts.
+    #[test]
+    fn a_pool_starting_at_one_can_still_grow() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(1, 4);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let grower = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_micros(500));
+            p2.set_threads(4);
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        grower.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// Shrinking must never retire the last worker.
+    ///
+    /// The assertion is that this test *finishes*. If the pool could empty
+    /// itself there would be no worker left to reach EOF, `thread::scope` would
+    /// wait on threads that no longer exist to be created, and the test would
+    /// hang rather than fail. Sampling `live()` instead would race the end of
+    /// the run, where zero is the correct answer.
+    #[test]
+    fn shrinking_always_leaves_one_worker() {
+        const N: usize = 400_000;
+        let pool = ThreadPool::with_max(8, 8);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let s2 = stop.clone();
+        let shrinker = std::thread::spawn(move || {
+            for n in (1..=8).rev() {
+                if s2.load(Ordering::Relaxed) {
+                    break;
+                }
+                p2.set_threads(n);
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        stop.store(true, Ordering::Relaxed);
+        shrinker.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// The property that has to hold under arbitrary resizing: every record is
+    /// processed exactly once, however many workers come and go.
+    #[test]
+    fn thread_churn_processes_every_record_exactly_once() {
+        const N: usize = 200_000;
+        let pool = ThreadPool::with_max(4, 16);
+        let mut proc = TallyProcessor::default();
+
+        let p2 = pool.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let s2 = stop.clone();
+        let churner = std::thread::spawn(move || {
+            let mut n = 1;
+            while !s2.load(Ordering::Relaxed) {
+                n = if n >= 16 { 1 } else { n + 3 };
+                p2.set_threads(n);
+                std::thread::sleep(std::time::Duration::from_micros(100));
+            }
+        });
+
+        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
+        reader.process_parallel_pool(&mut proc, &pool).unwrap();
+        stop.store(true, Ordering::Relaxed);
+        churner.join().unwrap();
+
+        assert_eq!(proc.total.load(Ordering::Relaxed), N);
+    }
+
+    /// A pool never exceeds the ceiling it was built with.
+    #[test]
+    fn the_maximum_is_respected() {
+        let pool = ThreadPool::with_max(2, 4);
+        pool.set_threads(999);
+        assert_eq!(pool.threads(), 4);
+        pool.set_threads(0);
+        assert_eq!(
+            pool.threads(),
+            1,
+            "a pool must always want at least one worker"
         );
     }
 }

--- a/src/parallel/single.rs
+++ b/src/parallel/single.rs
@@ -3,8 +3,8 @@ use itertools::Itertools;
 use crate::parallel::ordered::OrderGate;
 use crate::parallel::processor::GenericProcessor;
 use crate::parallel::{error::Result, ProcessError};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 
 /// A Sync version of GenericReader, i.e. for types with internal mutexes that can be shared between threads.
@@ -108,47 +108,19 @@ where
 }
 
 pub(crate) fn process_parallel_generic_range<S: MTGenericReader, T>(
-    reader: S,
-    processor: &mut T,
-    num_threads: usize,
-    offset: usize,
-    limit: Option<usize>,
-) -> Result<()>
-where
-    T: for<'a> GenericProcessor<S::RefRecord<'a>>,
-{
-    // A pool whose target never moves is exactly a fixed worker count. There is
-    // one implementation rather than two, so the resizable path cannot drift
-    // from the fixed one.
-    process_parallel_pool_range(
-        reader,
-        processor,
-        &crate::parallel::ThreadPool::new(num_threads),
-        offset,
-        limit,
-    )
-}
-
-/// As [`process_parallel_generic_range`], but the worker count may change while
-/// the run is in flight. See [`crate::parallel::ThreadPool`].
-pub(crate) fn process_parallel_pool_range<S: MTGenericReader, T>(
     mut reader: S,
     processor: &mut T,
-    pool: &crate::parallel::ThreadPool,
+    mut num_threads: usize,
     offset: usize,
     limit: Option<usize>,
 ) -> Result<()>
 where
     T: for<'a> GenericProcessor<S::RefRecord<'a>>,
 {
-    let mut num_threads = pool.share_target();
     if num_threads == 0 {
         num_threads = num_cpus::get();
     }
-    // Only when the pool can never grow. A pool that *starts* at one worker but
-    // may be resized has to take the parallel path anyway, or it could never
-    // honour a later `set_threads` -- there is no pool in the sequential path.
-    if num_threads == 1 && pool.share_max() == 1 {
+    if num_threads == 1 {
         return process_sequential_generic_range(reader, processor, offset, limit);
     }
 
@@ -158,205 +130,113 @@ where
     let order_gate = Arc::new(OrderGate::new());
     let ordered = processor.requires_ordering();
 
-    let first_error: Mutex<Option<ProcessError>> = Mutex::new(None);
-    // Set at end of input (or when the record limit is reached). Parked
-    // workers wait on the pool's gate with this in their predicate, so setting
-    // it must be paired with `pool.wake_all()` or they would sleep forever.
-    let finished = AtomicBool::new(false);
-
     thread::scope(|scope| -> Result<()> {
         let reader = &reader;
-        let ctx = WorkerCtx {
-            reader,
-            pool,
-            first_error: &first_error,
-            finished: &finished,
-            order_gate: &order_gate,
-            ordered,
-            offset,
-            limit,
-        };
 
-        // The whole spawn set, once, each worker with a stable index. A worker
-        // whose index is at or above the target parks immediately (allocating
-        // nothing); growth wakes it. Because nothing ever spawns after this
-        // loop, the worker count is bounded by construction -- there is no
-        // claim/release accounting to race against EOF.
-        for worker_id in 0..pool.share_max() {
-            spawn_worker(
-                scope,
-                &ctx,
-                worker_id,
-                processor.clone(),
-                records_processed.clone(),
-            );
+        let mut handles = Vec::new();
+        for thread_id in 0..num_threads {
+            let mut worker_processor = processor.clone();
+            let mut record_set = reader.new_record_set();
+            let records_processed = records_processed.clone();
+            let order_gate = order_gate.clone();
+
+            let handle = scope.spawn(move || {
+                // Run the worker body in a closure so any error path below can
+                // poison the order gate before propagating - otherwise other
+                // threads waiting on a batch that will never complete would
+                // deadlock instead of unwinding.
+                let result: Result<()> = (|| {
+                    worker_processor.set_thread_id(thread_id);
+
+                    loop {
+                        // Check limit before grabbing batch
+                        if let Some(lim) = limit {
+                            if records_processed.load(Ordering::Relaxed) >= lim {
+                                break;
+                            }
+                        }
+
+                        // Fill the batch; `fill` itself claims this batch's
+                        // stream position atomically (see the trait docs).
+                        let Some((batch_start, batch_end)) =
+                            reader.fill(&mut record_set).map_err(Into::into)?
+                        else {
+                            break; // EOF
+                        };
+                        let batch_size = batch_end - batch_start;
+
+                        // Determine overlap with target range [offset, offset+limit)
+                        let range_end = limit.map(|lim| offset + lim).unwrap_or(usize::MAX);
+
+                        if batch_end <= offset {
+                            // Entire batch before offset - skip it. Still catch
+                            // the order gate up to this point so the first
+                            // processed batch's wait_turn isn't stuck waiting
+                            // for skipped ground it will never claim.
+                            if ordered {
+                                order_gate.advance(batch_end);
+                            }
+                            continue;
+                        }
+
+                        if batch_start >= range_end {
+                            // Entire batch after limit - done
+                            break;
+                        }
+
+                        // Calculate slice of this batch within range
+                        let skip_in_batch = offset.saturating_sub(batch_start);
+                        let take_count = (batch_size - skip_in_batch)
+                            .min(range_end - batch_start - skip_in_batch);
+
+                        // Process the slice
+                        let records = S::iter(&record_set)
+                            .skip(skip_in_batch)
+                            .take(take_count)
+                            .map(|r| r.map_err(Into::into));
+
+                        records.process_results(|records| {
+                            worker_processor.process_record_batch(records)
+                        })??;
+
+                        records_processed.fetch_add(take_count, Ordering::Relaxed);
+
+                        // Only the commit step is serialized to stream order;
+                        // process_record_batch above already ran unordered.
+                        if ordered {
+                            order_gate.wait_turn(batch_start);
+                        }
+                        worker_processor.on_batch_complete()?;
+                        if ordered {
+                            order_gate.advance(batch_end);
+                        }
+                    }
+                    worker_processor.on_thread_complete()?;
+                    Ok(())
+                })();
+
+                if result.is_err() && ordered {
+                    order_gate.poison();
+                }
+                result
+            });
+
+            handles.push(handle);
         }
+
+        // Wait for workers
+        for handle in handles {
+            match handle.join() {
+                Ok(Ok(())) => (),
+                Ok(Err(e)) => return Err(e),
+                Err(_) => return Err(ProcessError::JoinError),
+            }
+        }
+
         Ok(())
     })?;
 
-    match first_error.into_inner().unwrap_or(None) {
-        Some(e) => Err(e),
-        None => Ok(()),
-    }
-}
-
-/// Everything a worker needs that is identical for every worker.
-///
-/// Grouped so that spawning one takes three arguments rather than a dozen, and
-/// so a worker can hand the same context to a successor.
-struct WorkerCtx<'env, S> {
-    reader: &'env S,
-    pool: &'env crate::parallel::ThreadPool,
-    first_error: &'env Mutex<Option<ProcessError>>,
-    finished: &'env AtomicBool,
-    order_gate: &'env Arc<OrderGate>,
-    ordered: bool,
-    offset: usize,
-    limit: Option<usize>,
-}
-
-impl<S> Clone for WorkerCtx<'_, S> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<S> Copy for WorkerCtx<'_, S> {}
-
-/// Run one worker of the fixed spawn set.
-///
-/// The worker parks when its index is at or above the target and resumes when
-/// growth brings the target back over it. It allocates its `RecordSet` lazily,
-/// on first activation, so a worker that never runs holds no batch memory.
-/// Parking happens only at a batch boundary, after the order gate has been
-/// advanced past the batch in hand, so ordered mode never waits on a turn a
-/// parked worker owes.
-fn spawn_worker<'scope, 'env, S, T>(
-    scope: &'scope thread::Scope<'scope, 'env>,
-    ctx: &WorkerCtx<'env, S>,
-    worker_id: usize,
-    mut worker_processor: T,
-    records_processed: Arc<AtomicUsize>,
-) where
-    S: MTGenericReader + Sync + 'env,
-    T: for<'a> GenericProcessor<S::RefRecord<'a>> + Send + 'env,
-{
-    let ctx = *ctx;
-    scope.spawn(move || {
-        let mut record_set: Option<S::RecordSet> = None;
-        let mut active = false;
-
-        // As in the fixed path: run the body in a closure so any error can
-        // poison the order gate before propagating, rather than deadlocking
-        // workers waiting on a batch that will never complete.
-        let result: Result<()> = (|| {
-            worker_processor.set_thread_id(worker_id);
-
-            loop {
-                if ctx.finished.load(Ordering::Acquire) {
-                    break;
-                }
-                // Over target: park until growth or end of input. The
-                // predicate is re-checked under the pool's gate, and both
-                // `set_threads` and the finished path notify under that same
-                // gate, so the wakeup cannot be lost.
-                if worker_id >= ctx.pool.share_target() {
-                    if active {
-                        ctx.pool.exit_live();
-                        active = false;
-                    }
-                    // Parked memory is proportional to *active* workers: the
-                    // batch in this set was fully processed and the order gate
-                    // advanced past it before we got here, so its contents are
-                    // dead -- drop the buffers rather than hold megabytes idle
-                    // for however long the pool stays shrunk. Re-activation
-                    // re-allocates; resizes happen on controller cadences
-                    // (hundreds of ms), so the churn is noise.
-                    record_set = None;
-                    ctx.pool.park_until(|| {
-                        worker_id < ctx.pool.share_target() || ctx.finished.load(Ordering::Acquire)
-                    });
-                    continue;
-                }
-                if !active {
-                    ctx.pool.enter_live();
-                    active = true;
-                }
-                let record_set = record_set.get_or_insert_with(|| ctx.reader.new_record_set());
-
-                if let Some(lim) = ctx.limit {
-                    if records_processed.load(Ordering::Relaxed) >= lim {
-                        ctx.finished.store(true, Ordering::Release);
-                        ctx.pool.wake_all();
-                        break;
-                    }
-                }
-
-                let Some((batch_start, batch_end)) =
-                    ctx.reader.fill(record_set).map_err(Into::into)?
-                else {
-                    ctx.finished.store(true, Ordering::Release);
-                    ctx.pool.wake_all();
-                    break; // EOF
-                };
-                let batch_size = batch_end - batch_start;
-                let range_end = ctx.limit.map(|lim| ctx.offset + lim).unwrap_or(usize::MAX);
-
-                if batch_end <= ctx.offset {
-                    if ctx.ordered {
-                        ctx.order_gate.advance(batch_end);
-                    }
-                    continue;
-                }
-                if batch_start >= range_end {
-                    ctx.finished.store(true, Ordering::Release);
-                    ctx.pool.wake_all();
-                    break;
-                }
-
-                let skip_in_batch = ctx.offset.saturating_sub(batch_start);
-                let take_count =
-                    (batch_size - skip_in_batch).min(range_end - batch_start - skip_in_batch);
-
-                let records = S::iter(record_set)
-                    .skip(skip_in_batch)
-                    .take(take_count)
-                    .map(|r| r.map_err(Into::into));
-
-                records
-                    .process_results(|records| worker_processor.process_record_batch(records))??;
-
-                records_processed.fetch_add(take_count, Ordering::Relaxed);
-
-                if ctx.ordered {
-                    ctx.order_gate.wait_turn(batch_start);
-                }
-                worker_processor.on_batch_complete()?;
-                if ctx.ordered {
-                    ctx.order_gate.advance(batch_end);
-                }
-            }
-            worker_processor.on_thread_complete()?;
-            Ok(())
-        })();
-
-        if active {
-            ctx.pool.exit_live();
-        }
-        if let Err(e) = result {
-            if ctx.ordered {
-                ctx.order_gate.poison();
-            }
-            // An erroring worker also ends the run for its peers -- parked
-            // workers in particular, who would otherwise sleep until a wakeup
-            // that is never coming once their siblings have stopped filling.
-            ctx.finished.store(true, Ordering::Release);
-            ctx.pool.wake_all();
-            let mut slot = ctx.first_error.lock().unwrap();
-            if slot.is_none() {
-                *slot = Some(e);
-            }
-        }
-    });
+    Ok(())
 }
 
 #[cfg(test)]
@@ -919,382 +799,6 @@ mod tests {
             p5.count(),
             50,
             "multi-interleaved should process 50 record-groups"
-        );
-    }
-}
-
-#[cfg(test)]
-mod pool_tests {
-    use std::io::Cursor;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
-
-    use crate::fastq;
-    use crate::parallel::{ParallelProcessor, ParallelReader, ProcessError, ThreadPool};
-    use crate::Record;
-
-    fn make_fastq(n: usize) -> Vec<u8> {
-        (0..n)
-            .flat_map(|i| format!("@seq{i}\nACGT\n+\nIIII\n").into_bytes())
-            .collect()
-    }
-
-    /// Deliberately keeps per-thread state and only publishes it in
-    /// `on_thread_complete`, exactly as a real processor does. That is what
-    /// makes it sensitive to *where* a new worker's clone comes from.
-    #[derive(Clone, Default)]
-    struct TallyProcessor {
-        total: Arc<AtomicUsize>,
-        threads_completed: Arc<AtomicUsize>,
-        local: usize,
-    }
-
-    impl<Rf: Record> ParallelProcessor<Rf> for TallyProcessor {
-        fn process_record(&mut self, _record: Rf) -> Result<(), ProcessError> {
-            self.local += 1;
-            Ok(())
-        }
-        fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
-            self.total.fetch_add(self.local, Ordering::Relaxed);
-            self.threads_completed.fetch_add(1, Ordering::Relaxed);
-            self.local = 0;
-            Ok(())
-        }
-    }
-
-    /// A pool that never resizes must behave exactly like a fixed count.
-    #[test]
-    fn a_fixed_pool_matches_a_fixed_thread_count() {
-        const N: usize = 5_000;
-        for threads in [1usize, 2, 8] {
-            let mut proc = TallyProcessor::default();
-            let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
-            reader
-                .process_parallel_pool(&mut proc, &ThreadPool::new(threads))
-                .unwrap();
-            assert_eq!(proc.total.load(Ordering::Relaxed), N, "threads {threads}");
-        }
-    }
-
-    /// Regression: a worker leaving at EOF used to drop `live` below
-    /// `target`, every remaining worker read that as "the pool is short" and
-    /// spawned a replacement, which hit EOF and did the same — 3.1 million
-    /// workers for a 32-thread run over an 8 M record file. Even with an EOF
-    /// guard, a small input could race 9 concurrent workers into an 8-worker
-    /// pool, because peers made spawn decisions from observed live counts.
-    ///
-    /// The fixed spawn set makes the bound structural: workers are spawned
-    /// once with stable indices and nothing spawns afterwards, so there is no
-    /// decision left to race on. The input here is deliberately tiny (the size
-    /// at which the old design failed deterministically), the run is repeated,
-    /// and *concurrency* is measured directly rather than inferred from
-    /// completion counts.
-    #[test]
-    fn worker_concurrency_is_bounded_by_construction() {
-        const N: usize = 200;
-        #[derive(Clone, Default)]
-        struct ConcurrencyProbe {
-            current: Arc<AtomicUsize>,
-            peak: Arc<AtomicUsize>,
-            total: Arc<AtomicUsize>,
-        }
-        impl<Rf: crate::Record> crate::parallel::ParallelProcessor<Rf> for ConcurrencyProbe {
-            fn process_record(&mut self, _r: Rf) -> Result<(), ProcessError> {
-                let now = self.current.fetch_add(1, Ordering::AcqRel) + 1;
-                self.peak.fetch_max(now, Ordering::AcqRel);
-                self.total.fetch_add(1, Ordering::Relaxed);
-                self.current.fetch_sub(1, Ordering::AcqRel);
-                Ok(())
-            }
-        }
-
-        for _ in 0..25 {
-            let proc_template = ConcurrencyProbe::default();
-            let mut proc = proc_template.clone();
-            let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
-            reader
-                .process_parallel_pool(&mut proc, &ThreadPool::new(8))
-                .unwrap();
-            assert_eq!(proc_template.total.load(Ordering::Relaxed), N);
-            let peak = proc_template.peak.load(Ordering::Relaxed);
-            assert!(
-                peak <= 8,
-                "{peak} concurrent workers in an 8-worker pool: the spawn-set \
-                 bound has been broken"
-            );
-        }
-    }
-
-    /// Regression: new workers must be cloned from the caller's pristine
-    /// processor, never from a running one.
-    ///
-    /// `Clone` on a processor means "give me a fresh worker". Cloning a worker
-    /// mid-flight copies its accumulated `local`, and both copies then publish
-    /// it in `on_thread_complete` -- turning 8 M records into 791 billion.
-    #[test]
-    fn grown_workers_start_from_a_pristine_processor() {
-        const N: usize = 200_000;
-        let pool = ThreadPool::with_max(1, 8);
-        let mut proc = TallyProcessor::default();
-
-        let p2 = pool.clone();
-        let grower = std::thread::spawn(move || {
-            for n in 2..=8 {
-                std::thread::sleep(std::time::Duration::from_micros(200));
-                p2.set_threads(n);
-            }
-        });
-
-        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
-        reader.process_parallel_pool(&mut proc, &pool).unwrap();
-        grower.join().unwrap();
-
-        assert_eq!(
-            proc.total.load(Ordering::Relaxed),
-            N,
-            "records were counted more than once: a growing worker inherited \
-             another worker's partial tally"
-        );
-    }
-
-    /// Growth has to be reachable from a single worker, which means the
-    /// `num_threads == 1` sequential short-circuit must look at whether the
-    /// pool *can* grow, not at where it starts.
-    #[test]
-    fn a_pool_starting_at_one_can_still_grow() {
-        const N: usize = 200_000;
-        let pool = ThreadPool::with_max(1, 4);
-        let mut proc = TallyProcessor::default();
-
-        let p2 = pool.clone();
-        let grower = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_micros(500));
-            p2.set_threads(4);
-        });
-
-        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
-        reader.process_parallel_pool(&mut proc, &pool).unwrap();
-        grower.join().unwrap();
-
-        assert_eq!(proc.total.load(Ordering::Relaxed), N);
-    }
-
-    /// Shrinking must never retire the last worker.
-    ///
-    /// The assertion is that this test *finishes*. If the pool could empty
-    /// itself there would be no worker left to reach EOF, `thread::scope` would
-    /// wait on threads that no longer exist to be created, and the test would
-    /// hang rather than fail. Sampling `live()` instead would race the end of
-    /// the run, where zero is the correct answer.
-    #[test]
-    fn shrinking_always_leaves_one_worker() {
-        const N: usize = 400_000;
-        let pool = ThreadPool::with_max(8, 8);
-        let mut proc = TallyProcessor::default();
-
-        let p2 = pool.clone();
-        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let s2 = stop.clone();
-        let shrinker = std::thread::spawn(move || {
-            for n in (1..=8).rev() {
-                if s2.load(Ordering::Relaxed) {
-                    break;
-                }
-                p2.set_threads(n);
-                std::thread::sleep(std::time::Duration::from_micros(200));
-            }
-        });
-
-        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
-        reader.process_parallel_pool(&mut proc, &pool).unwrap();
-        stop.store(true, Ordering::Relaxed);
-        shrinker.join().unwrap();
-
-        assert_eq!(proc.total.load(Ordering::Relaxed), N);
-    }
-
-    /// The property that has to hold under arbitrary resizing: every record is
-    /// processed exactly once, however many workers come and go.
-    #[test]
-    fn thread_churn_processes_every_record_exactly_once() {
-        const N: usize = 200_000;
-        let pool = ThreadPool::with_max(4, 16);
-        let mut proc = TallyProcessor::default();
-
-        let p2 = pool.clone();
-        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let s2 = stop.clone();
-        let churner = std::thread::spawn(move || {
-            let mut n = 1;
-            while !s2.load(Ordering::Relaxed) {
-                n = if n >= 16 { 1 } else { n + 3 };
-                p2.set_threads(n);
-                std::thread::sleep(std::time::Duration::from_micros(100));
-            }
-        });
-
-        let reader = fastq::Reader::new(Cursor::new(make_fastq(N)));
-        reader.process_parallel_pool(&mut proc, &pool).unwrap();
-        stop.store(true, Ordering::Relaxed);
-        churner.join().unwrap();
-
-        assert_eq!(proc.total.load(Ordering::Relaxed), N);
-    }
-
-    /// A supervisor outside the run needs the aggregate live count.
-    ///
-    /// `live()` reports one share, and the pool a caller holds is the *parent*,
-    /// whose own share never runs anything once a `Collection` splits it — so the
-    /// obvious reading is zero for the whole run. An external scheduler normalising
-    /// work against "threads running" then divides by nothing and concludes the
-    /// consumer is never busy.
-    #[test]
-    fn total_live_counts_workers_across_every_share() {
-        use crate::fastx::{Collection, CollectionType};
-
-        const N: usize = 200_000;
-        let pool = ThreadPool::with_max(8, 8);
-        let observer = pool.clone();
-        let seen = Arc::new(AtomicUsize::new(0));
-        let s2 = Arc::clone(&seen);
-        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let st2 = Arc::clone(&stop);
-        let watcher = std::thread::spawn(move || {
-            while !st2.load(Ordering::Relaxed) {
-                s2.fetch_max(observer.total_live(), Ordering::Relaxed);
-                std::thread::sleep(std::time::Duration::from_micros(200));
-            }
-        });
-
-        let mut proc = TallyProcessor::default();
-        let inner: Vec<_> = (0..4)
-            .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
-            .collect();
-        Collection::new(inner, CollectionType::Single)
-            .unwrap()
-            .process_parallel_pool(&mut proc, &pool, None)
-            .unwrap();
-        stop.store(true, Ordering::Relaxed);
-        watcher.join().unwrap();
-
-        assert_eq!(proc.total.load(Ordering::Relaxed), N * 4);
-        assert!(
-            seen.load(Ordering::Relaxed) > 1,
-            "peak total_live was {}, so shares are invisible to the parent",
-            seen.load(Ordering::Relaxed)
-        );
-        // And it unwinds: nothing is left counted after the run.
-        assert_eq!(pool.total_live(), 0, "live count leaked after the run");
-    }
-
-    /// A `Collection` splits its pool across the readers running at once.
-    ///
-    /// The regression this guards: handing every reader the *same* pool lets
-    /// the first claim every slot, so the rest spawn nothing. Since only a
-    /// running worker spawns another, those readers never start and their input
-    /// is silently skipped -- the counts come back short, with no error.
-    #[test]
-    fn a_collection_processes_every_reader_from_a_shared_pool() {
-        use crate::fastx::{Collection, CollectionType};
-
-        const N: usize = 5_000;
-        for readers in [1usize, 2, 4, 8] {
-            let mut proc = TallyProcessor::default();
-            let inner: Vec<_> = (0..readers)
-                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
-                .collect();
-            let collection = Collection::new(inner, CollectionType::Single).unwrap();
-            // Fewer threads than readers, so the split rounds down toward zero
-            // and every share has to be floored at one.
-            collection
-                .process_parallel_pool(&mut proc, &ThreadPool::new(2), None)
-                .unwrap();
-            assert_eq!(
-                proc.total.load(Ordering::Relaxed),
-                N * readers,
-                "{readers} readers: some reader was never started"
-            );
-        }
-    }
-
-    /// The same, for the grouped (paired) dispatch path.
-    #[test]
-    fn a_paired_collection_processes_every_group() {
-        use crate::fastx::{Collection, CollectionType};
-
-        const N: usize = 4_000;
-        #[derive(Clone, Default)]
-        struct PairTally {
-            total: Arc<AtomicUsize>,
-            local: usize,
-        }
-        impl<Rf: Record> crate::parallel::PairedParallelProcessor<Rf> for PairTally {
-            fn process_record_pair(&mut self, _r1: Rf, _r2: Rf) -> Result<(), ProcessError> {
-                self.local += 1;
-                Ok(())
-            }
-            fn on_thread_complete(&mut self) -> Result<(), ProcessError> {
-                self.total.fetch_add(self.local, Ordering::Relaxed);
-                self.local = 0;
-                Ok(())
-            }
-        }
-
-        for pairs in [1usize, 2, 4] {
-            let mut proc = PairTally::default();
-            let inner: Vec<_> = (0..pairs * 2)
-                .map(|_| crate::fastx::Reader::new(Cursor::new(make_fastq(N))).unwrap())
-                .collect();
-            let collection = Collection::new(inner, CollectionType::Paired).unwrap();
-            collection
-                .process_parallel_paired_pool(&mut proc, &ThreadPool::new(2), None)
-                .unwrap();
-            assert_eq!(
-                proc.total.load(Ordering::Relaxed),
-                N * pairs,
-                "{pairs} pairs: some group was never started"
-            );
-        }
-    }
-
-    /// A share reads the same target as its parent, so one `set_threads`
-    /// retargets every reader at once.
-    #[test]
-    fn shares_track_the_parent_target() {
-        let pool = ThreadPool::with_max(16, 32);
-        let a = pool.share(4);
-        let b = pool.share(4);
-        assert_eq!(a.share_target(), 4);
-        assert_eq!(b.share_target(), 4);
-
-        pool.set_threads(32);
-        assert_eq!(a.share_target(), 8, "a share must see the parent resize");
-        assert_eq!(b.share_target(), 8);
-
-        // A share never rounds down to zero workers.
-        let thin = pool.share(64);
-        assert_eq!(thin.share_target(), 1);
-        assert_eq!(thin.share_max(), 1);
-
-        // Live counts are per share, not shared.
-        a.enter_live();
-        assert_eq!(a.live(), 1);
-        assert_eq!(b.live(), 0);
-        assert_eq!(pool.total_live(), 1, "the parent sees the aggregate");
-        a.exit_live();
-    }
-
-    /// A pool never exceeds the ceiling it was built with.
-    #[test]
-    fn the_maximum_is_respected() {
-        let pool = ThreadPool::with_max(2, 4);
-        pool.set_threads(999);
-        assert_eq!(pool.threads(), 4);
-        pool.set_threads(0);
-        assert_eq!(
-            pool.threads(),
-            1,
-            "a pool must always want at least one worker"
         );
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,3 +5,6 @@ pub use crate::{
     },
     Record,
 };
+
+#[cfg(feature = "pool")]
+pub use crate::parallel::{PoolParallelReader, ThreadPool};


### PR DESCRIPTION
## Motivation and Reasoning

At @RagnarGrootKoerkamp's urging, I am adding some more (human token generated) reasoning and motivation to this PR.

I've recently developed [`rapidgzip-rust`](https://github.com/COMBINE-lab/rapidgzip-rust), a port of [`rapidgzip`](https://github.com/mxmlnkn/rapidgzip), but with some of its own capabilities. This allows for highly parallel decompression of gzipped files (among other variants like multi-member gzip, BGZF, etc.). That might itself be of interest to you in terms of enabling even faster conversion of FASTQ.gz -> CBQ. My purpose, of course, was to ingest reads more quickly for processing (mapping).

Of course, getting the reads more quickly is only half the challenge. The other challenge is to determine, in an individual experimental library layout (e.g. single vs. paired, 1 file, 2 files, many files, etc.) how to allocate thread budget. In the `paraseq` model, workers that open a compressed stream can be responsible for both the decompression triggered by a `read` call, and then the subsequent processing. This is great because it means with a single compression stream and no parallelism, you don't have to decide how many threads to allocate to decompression versus "work".

However, once you can decompress in parallel, the calculus becomes harder. Once you have more thread than files, you can use those extra threads for decompression, or you can use them to map decompressed chunks, etc.

To help address that issue, I created the [`thread-broker`](https://crates.io/crates/thread-broker) crate. It essentially measures producer ("decompression") and consumer ("parsing and mapping") rates, to determine the ideal allocation of threads to these tasks.  Those values, and hence, the ideal allocations, can change over the life of a program (as some files finish processing, for example).

Thus, the `thread-broker` want's to be able to "move" threads from one task to another. In reality, threads are not moved, they are just deactivated from one task (producer or consumer) and activated in another.  This works under the invariant that the total maximum number of threads active at any point is held fixed.

The thread broker makes initial rapid measurements at program start, determines and initial allocation, and then backs off, monitoring sparsely during program run to remain low overhead.  There's actually some cool dynamic scheduling theory that is uses (papers cited in the repo) to handle the tricky cases.  I think this paradigm could be generally useful in many bioinformatics tasks.

Anyway, that is the reason for this PR. In all the places where I currently use thread-broker (`salmon` and `piscem`), I also use `paraseq`. For the model to work, it needs the ability to tell `paraseq` to retire a worker, or to start a new worker if the pool is not yet saturated. This works in unison with a similar capability built into `rapidgzip-rust` (which, afaik, the original `rapidgzip` doesn't have).

The current approach should introduce a parallel `_with_pool` path, leaving the standard paths basically untouched.  Let me know what you think.

## Issue continuance

Reopens #75 against `main`, as suggested — but not as a rebase. Your review convinced me the design itself was wrong, so this is a redesign, and your instinct about pre-spawning was correct.

## What you found, confirmed and then some

`workers_leaving_at_eof_do_not_spawn_replacements` at N=200: **30 of 30 failures** on my machine — not flaky, deterministic at small inputs. The root cause is structural, not a missing guard: the old design let running workers make spawn decisions from observed live counts, and "a peer left at EOF" is not distinguishable from "the pool is short" from a peer's viewpoint. No guard fully closes that; the EOF flag only narrows the window.

## The redesign: fixed spawn set, parked when over target

- **Every worker the pool can ever run is spawned once, up front, with a stable index.** A worker whose index is ≥ the target parks on the pool's condvar at a batch boundary; growth wakes it. **Nothing ever spawns after the initial loop**, so the ceiling is a bound *by construction* — there is no spawn decision left to race on. The storm class and the overshoot become unrepresentable rather than guarded-against.
- **Memory is proportional to *active* workers.** A `RecordSet` is allocated lazily on first activation and dropped on park (the batch it held was fully processed and the order gate advanced before the park point), so a parked worker costs one OS thread and nothing else — no upstream `RecordSet` change needed after all, though thanks for offering it.
- **Net deletion, addressing the complexity concern**: the claim/release CAS accounting, the mid-flight template cloning, and the EOF-vs-shortfall disambiguation are all gone. The pool path stays behind its own entry points (`process_parallel_pool*`); the fixed path is untouched.
- One subtlety carried deliberately: park/wake follows strict check-then-wait discipline — the predicate is evaluated under the pool's gate, and `set_threads`, end-of-input, and the error path all notify while holding it. We recently debugged a lost-wakeup in another pool where the notify skipped the lock; the insidious part is that any *other* periodic notifier repairs the loss, so tests pass until the notifier goes quiet. (An early version of the regression test here had exactly that flaw — a resizer thread was rescuing the broken code.)

## Evidence

- Your repro is now the test: `worker_concurrency_is_bounded_by_construction` — N=200, 25 reps per run, concurrency measured directly (not inferred from completion counts). 500 accumulated tiny-input runs, zero violations.
- 136 lib tests pass, clippy clean.
- Downstream check: piscem-rs's resize-safety and thread-broker adapter suites (254 lib + 3 integration tests) pass against this branch unchanged — the public API (`set_threads` / `threads` / `live` / `total_live` / `share` / `with_max`) is source-compatible.

Happy to gate the pool module behind a feature as well if you'd still prefer that — with the fixed path now untouched, the isolation is mostly already there, but it's your call.
